### PR TITLE
Enable tab selection via URL

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,9 @@ const content = document.getElementById('content') as HTMLElement;
 type Tab = 'top' | 'novel' | 'game';
 
 async function loadTab(tab: Tab) {
+  // update location hash so reloading the page keeps the current tab
+  location.hash = tab;
+
   if (tab === 'top') {
     const { default: showTop } = await import('./top');
     showTop(content, loadTab);
@@ -16,5 +19,6 @@ async function loadTab(tab: Tab) {
   }
 }
 
-// load default tab
-loadTab('top');
+// load initial tab based on URL hash, defaulting to "top"
+const initialTab = (location.hash.replace('#', '') as Tab) || 'top';
+loadTab(initialTab);


### PR DESCRIPTION
## Summary
- load the main tab based on URL hash
- keep the hash updated when switching tabs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c78a53a508333bc4f84d15ec82f0c