### PR TITLE
Improve wall visibility by pulling back camera

### DIFF
--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -21,7 +21,7 @@ export default class DungeonView {
   private readonly FOV = Math.PI / 3
   private readonly numRays = 120
   private readonly maxDepth = 20
-  private readonly eyeOffset = 0.3
+  private readonly eyeOffset = 0.6
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene


### PR DESCRIPTION
## Summary
- adjust the eye offset so the camera sits further behind the player

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d9739d3bc8333b03551b073fa945d