### PR TITLE
Improve rotation animation realism

### DIFF
--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -116,7 +116,7 @@ export default class DungeonView {
     const overshootAngle = tweenAngle + overshoot
 
     this.player.dir = endDir
-    this.scene.tweens.timeline({
+    this.scene.tweens.chain({
       tweens: [
         {
           targets: this,

--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -112,8 +112,10 @@ export default class DungeonView {
       tweenAngle += Math.PI * 2
     }
 
-    const overshoot = Phaser.Math.DegToRad(3) * (delta > 0 ? 1 : -1)
+    const overshoot = Phaser.Math.DegToRad(1) * (delta > 0 ? 1 : -1)
     const overshootAngle = tweenAngle + overshoot
+
+    const blur = this.graphics.postFX.addBlur()
 
     this.player.dir = endDir
     this.scene.tweens.chain({
@@ -141,6 +143,7 @@ export default class DungeonView {
       ],
       onComplete: () => {
         this.isRotating = false
+        this.graphics.postFX.remove(blur)
         this.viewAngle = finalAngle
         this.draw()
         this.updateDebugText()

--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -112,35 +112,18 @@ export default class DungeonView {
       tweenAngle += Math.PI * 2
     }
 
-    const overshoot = Phaser.Math.DegToRad(1) * (delta > 0 ? 1 : -1)
-    const overshootAngle = tweenAngle + overshoot
-
     const blur = this.graphics.postFX.addBlur(0, 1, 1, 0.4)
 
     this.player.dir = endDir
-    this.scene.tweens.chain({
-      tweens: [
-        {
-          targets: this,
-          viewAngle: overshootAngle,
-          duration: this.rotateDuration * 0.7,
-          ease: Phaser.Math.Easing.Sine.In,
-          onUpdate: () => {
-            this.draw()
-            this.updateDebugText()
-          },
-        },
-        {
-          targets: this,
-          viewAngle: tweenAngle,
-          duration: this.rotateDuration * 0.3,
-          ease: Phaser.Math.Easing.Sine.Out,
-          onUpdate: () => {
-            this.draw()
-            this.updateDebugText()
-          },
-        },
-      ],
+    this.scene.tweens.add({
+      targets: this,
+      viewAngle: tweenAngle,
+      duration: this.rotateDuration,
+      ease: Phaser.Math.Easing.Sine.InOut,
+      onUpdate: () => {
+        this.draw()
+        this.updateDebugText()
+      },
       onComplete: () => {
         this.isRotating = false
         this.graphics.postFX.remove(blur)

--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -111,15 +111,34 @@ export default class DungeonView {
     } else if (this.viewAngle - tweenAngle > Math.PI) {
       tweenAngle += Math.PI * 2
     }
+
+    const overshoot = Phaser.Math.DegToRad(3) * (delta > 0 ? 1 : -1)
+    const overshootAngle = tweenAngle + overshoot
+
     this.player.dir = endDir
-    this.scene.tweens.add({
-      targets: this,
-      viewAngle: tweenAngle,
-      duration: this.rotateDuration,
-      onUpdate: () => {
-        this.draw()
-        this.updateDebugText()
-      },
+    this.scene.tweens.timeline({
+      tweens: [
+        {
+          targets: this,
+          viewAngle: overshootAngle,
+          duration: this.rotateDuration * 0.7,
+          ease: Phaser.Math.Easing.Sine.In,
+          onUpdate: () => {
+            this.draw()
+            this.updateDebugText()
+          },
+        },
+        {
+          targets: this,
+          viewAngle: tweenAngle,
+          duration: this.rotateDuration * 0.3,
+          ease: Phaser.Math.Easing.Sine.Out,
+          onUpdate: () => {
+            this.draw()
+            this.updateDebugText()
+          },
+        },
+      ],
       onComplete: () => {
         this.isRotating = false
         this.viewAngle = finalAngle

--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -115,7 +115,7 @@ export default class DungeonView {
     const overshoot = Phaser.Math.DegToRad(1) * (delta > 0 ? 1 : -1)
     const overshootAngle = tweenAngle + overshoot
 
-    const blur = this.graphics.postFX.addBlur()
+    const blur = this.graphics.postFX.addBlur(0, 1, 1, 0.4)
 
     this.player.dir = endDir
     this.scene.tweens.chain({


### PR DESCRIPTION
## Summary
- use sine easing and overshoot for rotation animation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687da0c3df0c8333bf17a06646c40a67