### PR TITLE
Add Perlin noise floor height

### DIFF
--- a/src/games/dungeon-rpg/DungeonMap.ts
+++ b/src/games/dungeon-rpg/DungeonMap.ts
@@ -1,17 +1,21 @@
 import type { Direction } from './Player'
+import PerlinNoise from './utils/PerlinNoise'
 
 export default class DungeonMap {
   tiles: string[]
   width: number
   height: number
+  heights: number[][]
   private _playerStart: { x: number; y: number; dir: Direction }
 
   constructor(width = 31, height = 31) {
     this.width = width
     this.height = height
     this.tiles = Array.from({ length: height }, () => '#'.repeat(width))
+    this.heights = Array.from({ length: height }, () => Array.from({ length: width }, () => 0))
     this._playerStart = { x: 1, y: 1, dir: 'north' }
     this.generate()
+    this.generateHeights()
   }
 
   get playerStart() {
@@ -77,6 +81,25 @@ export default class DungeonMap {
       }
       rooms.push(room)
     }
+  }
+
+  private generateHeights() {
+    const noise = new PerlinNoise()
+    const freq = 0.2
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        this.heights[y][x] = noise.noise2D(x * freq, y * freq)
+      }
+    }
+  }
+
+  heightAt(x: number, y: number): number {
+    const ix = Math.floor(x)
+    const iy = Math.floor(y)
+    if (iy < 0 || iy >= this.height || ix < 0 || ix >= this.width) {
+      return 0.5
+    }
+    return this.heights[iy][ix]
   }
 
   tileAt(x: number, y: number): string {

--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -24,6 +24,7 @@ export default class DungeonView {
   private readonly numRays = 120
   private readonly maxDepth = 20
   private readonly eyeOffset = 0.6
+  private readonly floorAmplitude = 15
 
   constructor(scene: Phaser.Scene) {
     this.scene = scene
@@ -260,10 +261,12 @@ export default class DungeonView {
     const height = this.scene.scale.height
     const g = this.graphics
 
-    g.setPosition(0, this.bobOffset)
+    const eyeH = this.map.heightAt(this.viewX, this.viewY)
+    g.setPosition(0, this.bobOffset - this.floorAmplitude * (eyeH - 0.5))
     g.clear()
     g.fillStyle(0x666666, 1)
     g.fillRect(0, 0, width, height / 2)
+
     g.fillStyle(0x333333, 1)
     g.fillRect(0, height / 2, width, height / 2)
 
@@ -282,14 +285,26 @@ export default class DungeonView {
       const h = Math.min(height, wallScale / Math.max(corrected, 0.0001))
       const shade = Math.max(0, 200 - corrected * 40)
       const color = Phaser.Display.Color.GetColor(shade, shade, shade)
+      const cellHeight = this.map.heightAt(hit.cellX, hit.cellY)
+      const offset = this.floorAmplitude * (cellHeight - 0.5)
+      const top = (height - h) / 2 - offset
       g.fillStyle(color, 1)
-      g.fillRect(i * sliceW, (height - h) / 2, sliceW + 1, h)
+      g.fillRect(i * sliceW, top, sliceW + 1, h)
+
+      const floorShade = 51 + offset
+      const floorColor = Phaser.Display.Color.GetColor(
+        floorShade,
+        floorShade,
+        floorShade
+      )
+      g.fillStyle(floorColor, 1)
+      g.fillRect(i * sliceW, top + h, sliceW + 1, height - (top + h))
 
       if (prevSide !== null && prevSide !== hit.side) {
         g.lineStyle(1, 0xffffff, 0.3)
         g.beginPath()
-        g.moveTo(i * sliceW, (height - h) / 2)
-        g.lineTo(i * sliceW, (height + h) / 2)
+        g.moveTo(i * sliceW, top)
+        g.lineTo(i * sliceW, top + h)
         g.strokePath()
       }
       prevSide = hit.side

--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -283,15 +283,15 @@ export default class DungeonView {
       const corrected = hit.dist * Math.cos(rayAngle - dirAngle)
       const wallScale = width * 0.35
       const h = Math.min(height, wallScale / Math.max(corrected, 0.0001))
-      const shade = Math.max(0, 200 - corrected * 40)
-      const color = Phaser.Display.Color.GetColor(shade, shade, shade)
       const cellHeight = this.map.heightAt(hit.cellX, hit.cellY)
       const offset = this.floorAmplitude * (cellHeight - 0.5)
+      const shade = Math.max(0, 200 - corrected * 40 + offset * 3)
+      const color = Phaser.Display.Color.GetColor(shade, shade, shade)
       const top = (height - h) / 2 - offset
       g.fillStyle(color, 1)
       g.fillRect(i * sliceW, top, sliceW + 1, h)
 
-      const floorShade = 51 + offset
+      const floorShade = Phaser.Math.Clamp(50 + offset * 8, 0, 255)
       const floorColor = Phaser.Display.Color.GetColor(
         floorShade,
         floorShade,

--- a/src/games/dungeon-rpg/utils/PerlinNoise.ts
+++ b/src/games/dungeon-rpg/utils/PerlinNoise.ts
@@ -1,0 +1,66 @@
+export default class PerlinNoise {
+  private perm: number[]
+  constructor(seed = Math.random()) {
+    this.perm = new Array(512)
+    const p = new Array(256).fill(0).map((_, i) => i)
+    const rnd = this.mulberry32(Math.floor(seed * 0xffffffff))
+    for (let i = 255; i >= 0; i--) {
+      const j = Math.floor(rnd() * (i + 1))
+      ;[p[i], p[j]] = [p[j], p[i]]
+    }
+    for (let i = 0; i < 512; i++) {
+      this.perm[i] = p[i & 255]
+    }
+  }
+
+  private mulberry32(a: number) {
+    return function () {
+      a |= 0
+      a = (a + 0x6d2b79f5) | 0
+      let t = Math.imul(a ^ (a >>> 15), 1 | a)
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+  }
+
+  private fade(t: number) {
+    return t * t * t * (t * (t * 6 - 15) + 10)
+  }
+
+  private lerp(t: number, a: number, b: number) {
+    return a + t * (b - a)
+  }
+
+  private grad(hash: number, x: number, y: number) {
+    switch (hash & 3) {
+      case 0:
+        return x + y
+      case 1:
+        return -x + y
+      case 2:
+        return x - y
+      default:
+        return -x - y
+    }
+  }
+
+  noise2D(x: number, y: number) {
+    const X = Math.floor(x) & 255
+    const Y = Math.floor(y) & 255
+    const xf = x - Math.floor(x)
+    const yf = y - Math.floor(y)
+
+    const topRight = this.perm[this.perm[X + 1] + Y + 1]
+    const topLeft = this.perm[this.perm[X] + Y + 1]
+    const bottomRight = this.perm[this.perm[X + 1] + Y]
+    const bottomLeft = this.perm[this.perm[X] + Y]
+
+    const u = this.fade(xf)
+    const v = this.fade(yf)
+
+    const x1 = this.lerp(u, this.grad(bottomLeft, xf, yf), this.grad(bottomRight, xf - 1, yf))
+    const x2 = this.lerp(u, this.grad(topLeft, xf, yf - 1), this.grad(topRight, xf - 1, yf - 1))
+
+    return (this.lerp(v, x1, x2) + 1) / 2
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `PerlinNoise` utility for 2D noise generation
- store height values for each tile in `DungeonMap`
- render floor offset and shading using noise values in `DungeonView`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687daaddef88833397104da2f645724b