### PR TITLE
Add pixelated filter for dungeon game

### DIFF
--- a/src/games/dungeon-rpg/game.ts
+++ b/src/games/dungeon-rpg/game.ts
@@ -23,6 +23,9 @@ export default function initGame(
       height: window.innerHeight,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },
+    render: {
+      pixelArt: true,
+    },
     scene: {
       preload() {},
       create() {

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -80,13 +80,17 @@
       transform: translateY(-4px);
     }
 
-    footer {
-      color: #fff;
-      margin-bottom: 1rem;
-      font-size: 0.8rem;
-      text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    }
-  </style>
+  footer {
+    color: #fff;
+    margin-bottom: 1rem;
+    font-size: 0.8rem;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  }
+  /* Ensure game pixels remain crisp when scaled */
+  #game-container canvas {
+    image-rendering: pixelated;
+  }
+</style>
 </head>
 <body>
   <div id="content"></div>


### PR DESCRIPTION
## Summary
- enable pixelated graphics in the Phaser config
- ensure the canvas scales with crisp pixels via CSS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687db1591cc0833388bbba72d13484d4