### PR TITLE
Implement soil floor using Perlin noise

### DIFF
--- a/src/games/dungeon-rpg/DungeonView.ts
+++ b/src/games/dungeon-rpg/DungeonView.ts
@@ -175,23 +175,36 @@ export default class DungeonView {
 
   private drawFloor(width: number, height: number) {
     const g = this.graphics
-    const step = 4
-    const scale = 0.1
-    for (let y = height / 2; y < height; y += step) {
-      for (let x = 0; x < width; x += step) {
-        const nx = this.viewX * 0.3 + x * scale
-        const ny = this.viewY * 0.3 + y * scale
-        let n = this.noise.noise(nx, ny)
-        n = (n + 1) / 2
-        const base = 80
-        const shade = Math.floor(base + n * 60)
-        const color = Phaser.Display.Color.GetColor(
-          shade,
-          shade * 0.8,
-          shade * 0.5
-        )
-        g.fillStyle(color, 1)
-        g.fillRect(x, y, step, step)
+    const tileSize = 16
+    const noiseStep = 4
+    const scale = 0.2
+    const startY = height / 2
+    const tilesX = Math.ceil(width / tileSize)
+    const tilesY = Math.ceil((height / 2) / tileSize)
+    const startX = Math.floor(this.viewX) - Math.floor(tilesX / 2)
+    const startTileY = Math.floor(this.viewY)
+
+    for (let ty = 0; ty < tilesY; ty++) {
+      for (let tx = 0; tx < tilesX; tx++) {
+        const worldX = startX + tx
+        const worldY = startTileY + ty
+        for (let py = 0; py < tileSize; py += noiseStep) {
+          for (let px = 0; px < tileSize; px += noiseStep) {
+            const nx = (worldX + px / tileSize) * scale
+            const ny = (worldY + py / tileSize) * scale
+            let n = this.noise.noise(nx, ny)
+            n = (n + 1) / 2
+            const shade = Math.floor(n * 255)
+            const color = Phaser.Display.Color.GetColor(shade, shade, shade)
+            g.fillStyle(color, 1)
+            g.fillRect(
+              tx * tileSize + px,
+              startY + ty * tileSize + py,
+              noiseStep,
+              noiseStep
+            )
+          }
+        }
       }
     }
   }

--- a/src/games/dungeon-rpg/PerlinNoise.ts
+++ b/src/games/dungeon-rpg/PerlinNoise.ts
@@ -1,0 +1,63 @@
+export default class PerlinNoise {
+  private perm: number[]
+
+  constructor(seed = 0) {
+    const p = new Array(256).fill(0).map((_, i) => i)
+    let n = seed
+    const random = () => {
+      n = (n * 9301 + 49297) % 233280
+      return n / 233280
+    }
+    for (let i = 255; i > 0; i--) {
+      const j = Math.floor(random() * (i + 1))
+      ;[p[i], p[j]] = [p[j], p[i]]
+    }
+    this.perm = new Array(512)
+    for (let i = 0; i < 512; i++) {
+      this.perm[i] = p[i & 255]
+    }
+  }
+
+  private fade(t: number): number {
+    return t * t * t * (t * (t * 6 - 15) + 10)
+  }
+
+  private lerp(t: number, a: number, b: number): number {
+    return a + t * (b - a)
+  }
+
+  private grad(hash: number, x: number, y: number): number {
+    const h = hash & 3
+    const u = h < 2 ? x : y
+    const v = h < 2 ? y : x
+    return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v)
+  }
+
+  noise(x: number, y: number): number {
+    const X = Math.floor(x) & 255
+    const Y = Math.floor(y) & 255
+
+    x -= Math.floor(x)
+    y -= Math.floor(y)
+
+    const u = this.fade(x)
+    const v = this.fade(y)
+
+    const A = this.perm[X] + Y
+    const B = this.perm[X + 1] + Y
+
+    return this.lerp(
+      v,
+      this.lerp(
+        u,
+        this.grad(this.perm[A], x, y),
+        this.grad(this.perm[B], x - 1, y)
+      ),
+      this.lerp(
+        u,
+        this.grad(this.perm[A + 1], x, y - 1),
+        this.grad(this.perm[B + 1], x - 1, y - 1)
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- add `PerlinNoise` utility for generating 2D Perlin noise
- render dungeon floor with noisy soil texture using the new class

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687db1adb1e48333816d4541e0e8ddd6