### PR TITLE
Add three.js demo tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "phaser": "^3.70.0",
+        "three": "^0.178.0",
         "vite": "^5.0.0"
       }
     },
@@ -865,6 +866,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/three": {
+      "version": "0.178.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.178.0.tgz",
+      "integrity": "sha512-ybFIB0+x8mz0wnZgSGy2MO/WCO6xZhQSZnmfytSPyNpM0sBafGRVhdaj+erYh5U+RhQOAg/eXqw5uVDiM2BjhQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.19",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "vite": "^5.0.0",
-    "phaser": "^3.70.0"
+    "phaser": "^3.70.0",
+    "three": "^0.178.0"
   }
 }

--- a/src/games/three-demo/demo.ts
+++ b/src/games/three-demo/demo.ts
@@ -1,0 +1,37 @@
+import * as THREE from 'three'
+
+export default function initThreeDemo(
+  container: HTMLElement,
+  loadTab: (tab: 'top') => void
+) {
+  container.innerHTML = `
+    <button id="back-to-top" style="position:absolute;z-index:1000;top:10px;left:10px;">トップへ戻る</button>
+    <div id="three-container" style="width:100%;height:100%"></div>
+  `
+  const back = container.querySelector('#back-to-top') as HTMLButtonElement
+  back.addEventListener('click', () => loadTab('top'))
+
+  const wrapper = container.querySelector('#three-container') as HTMLElement
+  const width = container.clientWidth
+  const height = container.clientHeight
+  const scene = new THREE.Scene()
+  const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000)
+  const renderer = new THREE.WebGLRenderer()
+  renderer.setSize(width, height)
+  wrapper.appendChild(renderer.domElement)
+
+  const geometry = new THREE.BoxGeometry()
+  const material = new THREE.MeshBasicMaterial({ color: 0x00ff00, wireframe: true })
+  const cube = new THREE.Mesh(geometry, material)
+  scene.add(cube)
+  camera.position.z = 5
+
+  function animate() {
+    requestAnimationFrame(animate)
+    cube.rotation.x += 0.01
+    cube.rotation.y += 0.01
+    renderer.render(scene, camera)
+  }
+
+  animate()
+}

--- a/src/tabs/main.ts
+++ b/src/tabs/main.ts
@@ -1,7 +1,7 @@
 
 const content = document.getElementById('content') as HTMLElement;
 
-type Tab = 'top' | 'novel' | 'game';
+type Tab = 'top' | 'novel' | 'game' | 'three';
 
 async function loadTab(tab: Tab) {
   // update location hash so reloading the page keeps the current tab
@@ -16,6 +16,9 @@ async function loadTab(tab: Tab) {
   } else if (tab === 'game') {
     const { default: initGame } = await import('../games/dungeon-rpg/game');
     initGame(content, loadTab);
+  } else if (tab === 'three') {
+    const { default: initThreeDemo } = await import('../games/three-demo/demo');
+    initThreeDemo(content, loadTab);
   }
 }
 

--- a/src/tabs/top.ts
+++ b/src/tabs/top.ts
@@ -1,19 +1,20 @@
 export default function showTop(
   container: HTMLElement,
-  loadTab: (tab: 'novel' | 'game') => void
+  loadTab: (tab: 'novel' | 'game' | 'three') => void
 ) {
   container.innerHTML = `
     <header>牧野大寧公式サイト</header>
     <div class="tiles">
       <div class="tile" data-tab="novel">小説</div>
       <div class="tile" data-tab="game">ビデオゲーム</div>
+      <div class="tile" data-tab="three">Three.js Demo</div>
     </div>
     <footer>&copy; 牧野大寧</footer>
   `;
   const tiles = container.querySelectorAll('.tile');
   tiles.forEach((tile) => {
     tile.addEventListener('click', () => {
-      const tab = (tile as HTMLElement).dataset.tab as 'novel' | 'game';
+      const tab = (tile as HTMLElement).dataset.tab as 'novel' | 'game' | 'three';
       loadTab(tab);
     });
   });


### PR DESCRIPTION
## Summary
- add three.js to dev dependencies
- create a simple rotating cube demo with Three.js
- add new "three" tab so demo can run alongside Phaser game

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dc6edadec833391fca8daf9fdd126