### PR TITLE
Implement migration step 3 – keyboard controls

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView.ts
+++ b/src/games/dungeon-rpg-three/DungeonView.ts
@@ -10,8 +10,20 @@ export default class DungeonView3D {
   private map: DungeonMap
   private player: Player
   private hero: Hero
+  private keys = new Set<string>()
+  private dirVectors: Record<
+    Direction,
+    {
+      dx: number
+      dy: number
+      left: { dx: number; dy: number }
+      right: { dx: number; dy: number }
+    }
+  >
+  private miniMap?: HTMLCanvasElement
+  private miniCtx?: CanvasRenderingContext2D
 
-  constructor(container: HTMLElement) {
+  constructor(container: HTMLElement, miniMap?: HTMLCanvasElement) {
     this.map = new DungeonMap()
     this.player = new Player(this.map.playerStart)
     this.hero = new Hero()
@@ -24,6 +36,20 @@ export default class DungeonView3D {
     this.renderer = new THREE.WebGLRenderer()
     this.renderer.setSize(width, height)
     container.appendChild(this.renderer.domElement)
+
+    this.miniMap = miniMap
+    if (this.miniMap) {
+      this.miniCtx = this.miniMap.getContext('2d') as CanvasRenderingContext2D
+    }
+
+    this.dirVectors = {
+      north: { dx: 0, dy: -1, left: { dx: -1, dy: 0 }, right: { dx: 1, dy: 0 } },
+      east: { dx: 1, dy: 0, left: { dx: 0, dy: -1 }, right: { dx: 0, dy: 1 } },
+      south: { dx: 0, dy: 1, left: { dx: 1, dy: 0 }, right: { dx: -1, dy: 0 } },
+      west: { dx: -1, dy: 0, left: { dx: 0, dy: 1 }, right: { dx: 0, dy: -1 } },
+    }
+
+    window.addEventListener('keydown', this.handleKeyDown)
 
     this.buildScene()
     this.updateCamera()
@@ -59,6 +85,78 @@ export default class DungeonView3D {
         }
       }
     }
+  }
+
+  private handleKeyDown = (e: KeyboardEvent) => {
+    const key = e.key.toLowerCase()
+    if (!['w', 'a', 's', 'd', 'j', 'k'].includes(key)) return
+    e.preventDefault()
+    const vectors = this.dirVectors[this.player.dir]
+    if (key === 'a') {
+      this.player.rotateLeft()
+    } else if (key === 'd') {
+      this.player.rotateRight()
+    } else if (key === 'w') {
+      const nx = this.player.x + vectors.dx
+      const ny = this.player.y + vectors.dy
+      if (this.map.tileAt(nx, ny) !== '#') {
+        this.player.x = nx
+        this.player.y = ny
+      }
+    } else if (key === 's') {
+      const nx = this.player.x - vectors.dx
+      const ny = this.player.y - vectors.dy
+      if (this.map.tileAt(nx, ny) !== '#') {
+        this.player.x = nx
+        this.player.y = ny
+      }
+    } else if (key === 'j') {
+      const nx = this.player.x + vectors.left.dx
+      const ny = this.player.y + vectors.left.dy
+      if (this.map.tileAt(nx, ny) !== '#') {
+        this.player.x = nx
+        this.player.y = ny
+      }
+    } else if (key === 'k') {
+      const nx = this.player.x + vectors.right.dx
+      const ny = this.player.y + vectors.right.dy
+      if (this.map.tileAt(nx, ny) !== '#') {
+        this.player.x = nx
+        this.player.y = ny
+      }
+    }
+    this.updateCamera()
+    this.renderMiniMap()
+  }
+
+  private renderMiniMap() {
+    if (!this.miniCtx || !this.miniMap) return
+    const ctx = this.miniCtx
+    const size = Math.min(this.miniMap.width, this.miniMap.height)
+    const cols = this.map.width
+    const rows = this.map.height
+    const cellW = size / cols
+    const cellH = size / rows
+    ctx.clearRect(0, 0, this.miniMap.width, this.miniMap.height)
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const cell = this.map.tileAt(c, r)
+        ctx.fillStyle = cell === '#' ? '#555' : '#222'
+        ctx.fillRect(c * cellW, r * cellH, cellW, cellH)
+        ctx.strokeStyle = '#888'
+        ctx.strokeRect(c * cellW, r * cellH, cellW, cellH)
+      }
+    }
+    const px = this.player.x * cellW + cellW / 2
+    const py = this.player.y * cellH + cellH / 2
+    ctx.fillStyle = '#f00'
+    ctx.beginPath()
+    ctx.arc(px, py, Math.min(cellW, cellH) / 3, 0, Math.PI * 2)
+    ctx.fill()
+  }
+
+  update() {
+    this.renderMiniMap()
   }
 
   private angleForDir(dir: Direction): number {

--- a/src/games/dungeon-rpg-three/game.ts
+++ b/src/games/dungeon-rpg-three/game.ts
@@ -6,15 +6,19 @@ export default function initThreeGame(
 ) {
   container.innerHTML = `
     <button id="back-to-top" style="position:absolute;z-index:1000;top:10px;left:10px;">トップへ戻る</button>
+    <canvas id="mini-map" width="150" height="150" style="position:absolute;z-index:500;top:10px;right:10px;border:1px solid #000"></canvas>
     <div id="three-game" style="width:100%;height:100%"></div>
   `
   const back = container.querySelector('#back-to-top') as HTMLButtonElement
   back.addEventListener('click', () => loadTab('top'))
 
   const wrapper = container.querySelector('#three-game') as HTMLElement
-  const view = new DungeonView3D(wrapper)
+  const miniMap = container.querySelector('#mini-map') as HTMLCanvasElement
+  container.style.position = 'relative'
+  const view = new DungeonView3D(wrapper, miniMap)
 
   function animate() {
+    view.update()
     view.render()
     requestAnimationFrame(animate)
   }


### PR DESCRIPTION
## Summary
- integrate keyboard input with Three.js dungeon view
- add simple canvas minimap overlay
- update game loop to call new update method

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687dcd7aeae483338ddcf50de4f5ca55