### PR TITLE
Fix camera rotation for opposite directions

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView.ts
+++ b/src/games/dungeon-rpg-three/DungeonView.ts
@@ -247,8 +247,9 @@ export default class DungeonView3D {
       const elapsed = performance.now() - this.animStart
       const t = Math.min(1, elapsed / this.animDuration)
       this.camera.position.lerpVectors(this.startPos, this.targetPos, t)
-      this.camera.rotation.y =
-        this.startRot + (this.targetRot - this.startRot) * t
+      let rotDiff = this.targetRot - this.startRot
+      rotDiff = ((rotDiff + Math.PI) % (Math.PI * 2)) - Math.PI
+      this.camera.rotation.y = this.startRot + rotDiff * t
       if (this.torch) {
         this.torch.position.set(
           this.camera.position.x,


### PR DESCRIPTION
## Summary
- handle camera rotation across π correctly
- ensure the camera always rotates shortest way

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ddbd00f9c833396bbb684ce5cc6af