### PR TITLE
Fix rotation interpolation across south boundary

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView.ts
+++ b/src/games/dungeon-rpg-three/DungeonView.ts
@@ -365,7 +365,9 @@ export default class DungeonView3D {
       const t = Math.min(1, elapsed / this.animDuration)
       this.camera.position.lerpVectors(this.startPos, this.targetPos, t)
       let rotDiff = this.targetRot - this.startRot
-      rotDiff = ((rotDiff + Math.PI) % (Math.PI * 2)) - Math.PI
+      rotDiff =
+        ((rotDiff + Math.PI) % (Math.PI * 2) + Math.PI * 2) % (Math.PI * 2) -
+        Math.PI
       this.camera.rotation.y = this.startRot + rotDiff * t
       if (this.torch) {
         this.torch.position.set(


### PR DESCRIPTION
## Summary
- fix how the camera rotation interpolates across the south direction so turns from south to southeast behave like others

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e03e9d8cc8333bee2dff5310d0b5e