### PR TITLE
Add separate hand states and input actions

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView.ts
+++ b/src/games/dungeon-rpg-three/DungeonView.ts
@@ -233,7 +233,7 @@ export default class DungeonView3D {
 
   private handleKeyDown = (e: KeyboardEvent) => {
     const key = e.key.toLowerCase()
-    if (!['w', 'a', 's', 'd', 'j', 'k'].includes(key)) return
+    if (!['w', 'a', 's', 'd', 'j', 'k', 'u', 'i'].includes(key)) return
     e.preventDefault()
     const vectors = this.dirVectors[this.player.dir]
 
@@ -265,9 +265,31 @@ export default class DungeonView3D {
       tryMove(vectors.left.dx, vectors.left.dy)
     } else if (key === 'k') {
       tryMove(vectors.right.dx, vectors.right.dy)
+    } else if (key === 'u') {
+      this.handleHandAction(true)
+    } else if (key === 'i') {
+      this.handleHandAction(false)
     }
     this.updateCamera()
     this.renderMiniMap()
+  }
+
+  private handleHandAction(left: boolean) {
+    const vectors = this.dirVectors[this.player.dir]
+    const targetX = Math.floor(this.player.x + vectors.dx)
+    const targetY = Math.floor(this.player.y + vectors.dy)
+    const enemy = this.enemies.find((e) => e.x === targetX && e.y === targetY)
+    const hand = left ? 'leftHand' : 'rightHand'
+    const item = (this.hero as any)[hand] as string
+    if (item === 'unarmed') {
+      if (enemy) {
+        console.log(`${left ? 'Left' : 'Right'} hand interacts with ${enemy.enemy.name}`)
+      } else {
+        console.log(`${left ? 'Left' : 'Right'} hand finds nothing`)
+      }
+    } else {
+      console.log(`${left ? 'Left' : 'Right'} hand uses ${item}`)
+    }
   }
 
   private renderMiniMap() {
@@ -441,6 +463,7 @@ export default class DungeonView3D {
     return (
       `Pos: ${pos} Dir: ${this.player.dir}\n` +
       `HP: ${this.hero.hp} STR: ${this.hero.strength}\n` +
+      `L: ${this.hero.leftHand} R: ${this.hero.rightHand}\n` +
       `Enemies: ${enemyInfo}`
     )
   }

--- a/src/games/dungeon-rpg/Hero.ts
+++ b/src/games/dungeon-rpg/Hero.ts
@@ -1,9 +1,18 @@
 export default class Hero {
   hp: number
   strength: number
+  leftHand: string
+  rightHand: string
 
-  constructor(hp = 10, strength = 5) {
+  constructor(
+    hp = 10,
+    strength = 5,
+    leftHand = 'unarmed',
+    rightHand = 'unarmed',
+  ) {
     this.hp = hp
     this.strength = strength
+    this.leftHand = leftHand
+    this.rightHand = rightHand
   }
 }


### PR DESCRIPTION
## Summary
- track left and right hand state on `Hero`
- display the new hand states in the 3D view debug panel
- map `u` and `i` keys to trigger left and right hand actions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e09b0f77083339b16658021cf945e