### PR TITLE
Add hunger and stamina UI

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -455,6 +455,14 @@ export default class DungeonView3D {
     this.renderer.render(this.scene, this.camera)
   }
 
+  getStatusHTML(): string {
+    const hungerIcon = '🍖'
+    const staminaIcon = '⚡'
+    const hunger = hungerIcon.repeat(this.hero.hunger)
+    const stamina = staminaIcon.repeat(this.hero.stamina)
+    return `${hunger} ${stamina}`
+  }
+
   getDebugText(): string {
     const pos = `(${this.player.x.toFixed(1)}, ${this.player.y.toFixed(1)})`
     const enemyInfo =
@@ -466,6 +474,7 @@ export default class DungeonView3D {
     return (
       `Pos: ${pos} Dir: ${this.player.dir}\n` +
       `HP: ${this.hero.hp} STR: ${this.hero.strength}\n` +
+      `Hunger: ${this.hero.hunger} Stamina: ${this.hero.stamina}\n` +
       `L: ${this.hero.leftHand} R: ${this.hero.rightHand}\n` +
       `Enemies: ${enemyInfo}`
     )

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -240,17 +240,19 @@ export default class DungeonView3D {
     const tryMove = (dx: number, dy: number) => {
       const nx = this.player.x + dx
       const ny = this.player.y + dy
-      if (this.map.tileAt(nx, ny) === '#') return
+      if (this.map.tileAt(nx, ny) === '#') return false
       const isDiag = Math.abs(dx) === 1 && Math.abs(dy) === 1
       if (
         isDiag &&
         (this.map.tileAt(this.player.x + dx, this.player.y) === '#' ||
           this.map.tileAt(this.player.x, this.player.y + dy) === '#')
       ) {
-        return
+        return false
       }
       this.player.x = nx
       this.player.y = ny
+      this.hero.hunger = Math.max(0, this.hero.hunger - 1)
+      return true
     }
 
     if (key === 'a') {
@@ -456,11 +458,13 @@ export default class DungeonView3D {
   }
 
   getStatusHTML(): string {
+    const heartIcon = '❤️'
     const hungerIcon = '🍖'
     const staminaIcon = '⚡'
-    const hunger = hungerIcon.repeat(this.hero.hunger)
+    const hearts = heartIcon.repeat(this.hero.hp)
+    const hunger = hungerIcon.repeat(Math.floor(this.hero.hunger / 100))
     const stamina = staminaIcon.repeat(this.hero.stamina)
-    return `${hunger} ${stamina}`
+    return `<div>${hearts}</div><div>${hunger}</div><div>${stamina}</div>`
   }
 
   getDebugText(): string {

--- a/src/games/dungeon-rpg-three/initGame.ts
+++ b/src/games/dungeon-rpg-three/initGame.ts
@@ -7,6 +7,7 @@ export default function initThreeGame(
   container.innerHTML = `
     <button id="back-to-top" style="position:absolute;z-index:1000;top:10px;left:10px;">トップへ戻る</button>
     <canvas id="mini-map" width="150" height="150" style="position:absolute;z-index:500;top:10px;right:10px;border:1px solid #000"></canvas>
+    <div id="status-display" style="position:absolute;z-index:700;top:10px;left:50%;transform:translateX(-50%);font-size:24px;color:#fff;text-shadow:0 0 2px #000"></div>
     <div id="debug-info" style="position:absolute;z-index:800;bottom:10px;left:10px;padding:4px;background:rgba(0,0,0,0.5);color:#fff;font:12px monospace;white-space:pre;"></div>
     <div id="arm-controls" style="position:absolute;z-index:600;top:10px;right:170px;padding:4px;background:rgba(0,0,0,0.5);color:#fff;font:12px monospace;">
       <div>PosY <input id="arm-pos-y" type="range" min="-1.2" max="0" step="0.01"></div>
@@ -26,6 +27,7 @@ export default function initThreeGame(
 
   const wrapper = container.querySelector('#three-game') as HTMLElement
   const miniMap = container.querySelector('#mini-map') as HTMLCanvasElement
+  const statusDiv = container.querySelector('#status-display') as HTMLDivElement
   const debugDiv = container.querySelector('#debug-info') as HTMLDivElement
   container.style.position = 'relative'
   const view = new DungeonView3D(wrapper, miniMap)
@@ -75,6 +77,9 @@ export default function initThreeGame(
     view.render()
     if (debugDiv) {
       debugDiv.textContent = view.getDebugText()
+    }
+    if (statusDiv) {
+      statusDiv.innerHTML = view.getStatusHTML()
     }
     requestAnimationFrame(animate)
   }

--- a/src/games/dungeon-rpg/Hero.ts
+++ b/src/games/dungeon-rpg/Hero.ts
@@ -3,16 +3,22 @@ export default class Hero {
   strength: number
   leftHand: string
   rightHand: string
+  hunger: number
+  stamina: number
 
   constructor(
     hp = 10,
     strength = 5,
     leftHand = 'unarmed',
     rightHand = 'unarmed',
+    hunger = 5,
+    stamina = 5,
   ) {
     this.hp = hp
     this.strength = strength
     this.leftHand = leftHand
     this.rightHand = rightHand
+    this.hunger = hunger
+    this.stamina = stamina
   }
 }

--- a/src/games/dungeon-rpg/Hero.ts
+++ b/src/games/dungeon-rpg/Hero.ts
@@ -11,7 +11,7 @@ export default class Hero {
     strength = 5,
     leftHand = 'unarmed',
     rightHand = 'unarmed',
-    hunger = 5,
+    hunger = 1000,
     stamina = 5,
   ) {
     this.hp = hp


### PR DESCRIPTION
## Summary
- track hero hunger and stamina
- render hunger/stamina icons at the top center of the screen

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e13db19948333ba1db6a8769c9f75