### PR TITLE
Add animation docs and Animator class

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ To build the project for production:
 npm run build
 ```
 
+## Animation Design
+
+See `docs/character-animation.md` for the approach used to animate characters
+with SVG or vertex JSON assets.
+

--- a/docs/character-animation.md
+++ b/docs/character-animation.md
@@ -1,0 +1,57 @@
+# Character Animation Design
+
+This project stores character meshes as vertex JSON generated from SVG data. To apply animations consistently, a common set of joints and body parts is defined for every character. Animations reference these joint names so they can be reused across models.
+
+## Skeleton and Joint Names
+
+Each character contains a hierarchy of joints. The following names are reserved:
+
+- `root`
+- `torso`
+- `head`
+- `leftShoulder`
+- `leftElbow`
+- `leftHand`
+- `rightShoulder`
+- `rightElbow`
+- `rightHand`
+- `leftHip`
+- `leftKnee`
+- `leftFoot`
+- `rightHip`
+- `rightKnee`
+- `rightFoot`
+
+A model may omit joints it does not use, but when present the joint should keep the same name. Every joint stores its pivot position relative to its parent.
+
+## Animation Clips
+
+Animations are described as JSON files containing keyframes. Each keyframe records the time (in seconds) and a partial pose for one or more joints.
+
+Example:
+
+```json
+{
+  "loop": true,
+  "keyframes": [
+    { "time": 0, "pose": { "leftShoulder": { "rotation": [0, 0, 0] } } },
+    { "time": 0.5, "pose": { "leftShoulder": { "rotation": [0, 0.2, 0] } } },
+    { "time": 1, "pose": { "leftShoulder": { "rotation": [0, 0, 0] } } }
+  ]
+}
+```
+
+By sharing the same joint names, animations such as shoulder sway or a jump can be applied to any character that implements this skeleton.
+
+## Animator Class
+
+The `Animator` class under `src/games/dungeon-rpg-three/components` manages playback of these animation clips. Pass it a map of joint objects when constructing. Call `play` with a clip and `update` each frame to interpolate joint transforms.
+
+## Asset Workflow
+
+1. Create body-part SVGs under `src/assets/.../svg`.
+2. Run `npm run convert-svgs` to generate vertex JSON files.
+3. Build a character by attaching the parts to joints defined above.
+4. Create animation JSON referencing the joint names.
+
+This approach keeps animations portable across characters and allows simple definitions for motions like jumping or idling.

--- a/src/games/dungeon-rpg-three/components/Animator.ts
+++ b/src/games/dungeon-rpg-three/components/Animator.ts
@@ -1,0 +1,90 @@
+import * as THREE from 'three'
+
+export interface JointMap {
+  [name: string]: THREE.Object3D
+}
+
+export interface JointPose {
+  position?: THREE.Vector3
+  rotation?: THREE.Euler
+  scale?: THREE.Vector3
+}
+
+export interface AnimationKeyframe {
+  time: number
+  pose: { [joint: string]: JointPose }
+}
+
+export interface AnimationClip {
+  loop: boolean
+  keyframes: AnimationKeyframe[]
+}
+
+export default class Animator {
+  private current?: AnimationClip
+  private startTime = 0
+
+  constructor(private joints: JointMap) {}
+
+  play(clip: AnimationClip) {
+    this.current = clip
+    this.startTime = performance.now()
+  }
+
+  update() {
+    if (!this.current) return
+    const { keyframes, loop } = this.current
+    if (keyframes.length === 0) return
+    const elapsed = (performance.now() - this.startTime) / 1000
+    const duration = keyframes[keyframes.length - 1].time
+    let t = elapsed
+    if (loop) {
+      t %= duration
+    } else {
+      t = Math.min(elapsed, duration)
+    }
+    let idx = 1
+    while (idx < keyframes.length && keyframes[idx].time < t) idx++
+    const prev = keyframes[idx - 1]
+    const next = keyframes[idx] || prev
+    const span = next.time - prev.time || 1
+    const f = (t - prev.time) / span
+
+    const apply = (obj: THREE.Object3D, a?: JointPose, b?: JointPose) => {
+      if (a?.rotation || b?.rotation) {
+        const q1 = a?.rotation
+          ? new THREE.Quaternion().setFromEuler(a.rotation)
+          : obj.quaternion
+        const q2 = b?.rotation
+          ? new THREE.Quaternion().setFromEuler(b.rotation)
+          : obj.quaternion
+        obj.quaternion.copy(q1).slerp(q2, f)
+      }
+      if (a?.position || b?.position) {
+        const v1 = a?.position || obj.position
+        const v2 = b?.position || obj.position
+        obj.position.set(
+          v1.x + (v2.x - v1.x) * f,
+          v1.y + (v2.y - v1.y) * f,
+          v1.z + (v2.z - v1.z) * f,
+        )
+      }
+      if (a?.scale || b?.scale) {
+        const s1 = a?.scale || obj.scale
+        const s2 = b?.scale || obj.scale
+        obj.scale.set(
+          s1.x + (s2.x - s1.x) * f,
+          s1.y + (s2.y - s1.y) * f,
+          s1.z + (s2.z - s1.z) * f,
+        )
+      }
+    }
+
+    Object.keys(this.joints).forEach((name) => {
+      const obj = this.joints[name]
+      const poseA = prev.pose[name]
+      const poseB = next.pose[name]
+      if (poseA || poseB) apply(obj, poseA, poseB)
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- document how to build SVG/vertex animations and define body joints
- reference the new design document from the main README
- implement a reusable `Animator` class for interpolating keyframes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e1a821eb483338496290f92b72370