### PR TITLE
Add arm sway animation

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -406,6 +406,7 @@ export default class DungeonView3D {
       this.arms.sway(t)
       if (t === 1) {
         this.animStart = null
+        this.arms.finishSway()
       }
     }
 

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -403,6 +403,7 @@ export default class DungeonView3D {
           this.camera.position.z
         )
       }
+      this.arms.sway(t)
       if (t === 1) {
         this.animStart = null
       }
@@ -451,6 +452,7 @@ export default class DungeonView3D {
     )
     this.targetRot = this.angleForDir(this.player.dir)
     this.animStart = performance.now()
+    this.arms.startSway()
   }
 
   render() {

--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -14,6 +14,8 @@ export default class PlayerArms {
   private fistDist = 0
   private baseLeftY = 0
   private baseRightY = 0
+  private readonly defaultLeftY: number
+  private readonly defaultRightY: number
 
   constructor(camera: THREE.Camera) {
     this.group = new THREE.Group()
@@ -74,6 +76,12 @@ export default class PlayerArms {
     this.leftUpper.position.set(-this.spacing, 0, -0.6)
     this.rightUpper.position.set(this.spacing, 0, -0.6)
 
+    // record default vertical positions for animation reset
+    this.defaultLeftY = this.leftUpper.position.y
+    this.defaultRightY = this.rightUpper.position.y
+    this.baseLeftY = this.defaultLeftY
+    this.baseRightY = this.defaultRightY
+
     this.group.add(this.leftUpper)
     this.group.add(this.rightUpper)
     this.group.position.y = -0.6
@@ -81,8 +89,16 @@ export default class PlayerArms {
   }
 
   startSway() {
-    this.baseLeftY = this.leftUpper.position.y
-    this.baseRightY = this.rightUpper.position.y
+    // reset arms to the default baseline before starting a new animation
+    this.leftUpper.position.y = this.defaultLeftY
+    this.rightUpper.position.y = this.defaultRightY
+    this.baseLeftY = this.defaultLeftY
+    this.baseRightY = this.defaultRightY
+  }
+
+  finishSway() {
+    this.leftUpper.position.y = this.defaultLeftY
+    this.rightUpper.position.y = this.defaultRightY
   }
 
   sway(t: number) {

--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -12,8 +12,8 @@ export default class PlayerArms {
   private spacing = 0.4
   private lowerDist = -0.06
   private fistDist = 0
-  private baseLeftRotX = 0
-  private baseRightRotX = 0
+  private baseLeftY = 0
+  private baseRightY = 0
 
   constructor(camera: THREE.Camera) {
     this.group = new THREE.Group()
@@ -81,15 +81,15 @@ export default class PlayerArms {
   }
 
   startSway() {
-    this.baseLeftRotX = this.leftUpper.rotation.x
-    this.baseRightRotX = this.rightUpper.rotation.x
+    this.baseLeftY = this.leftUpper.position.y
+    this.baseRightY = this.rightUpper.position.y
   }
 
   sway(t: number) {
     const swing = Math.sin(t * Math.PI)
-    const ampX = 0.1
-    this.leftUpper.rotation.x = this.baseLeftRotX + swing * ampX
-    this.rightUpper.rotation.x = this.baseRightRotX - swing * ampX
+    const ampY = 0.1
+    this.leftUpper.position.y = this.baseLeftY + swing * ampY
+    this.rightUpper.position.y = this.baseRightY - swing * ampY
   }
 
   getSettings() {

--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -14,8 +14,6 @@ export default class PlayerArms {
   private fistDist = 0
   private baseLeftRotX = 0
   private baseRightRotX = 0
-  private baseLeftRotZ = 0
-  private baseRightRotZ = 0
 
   constructor(camera: THREE.Camera) {
     this.group = new THREE.Group()
@@ -85,20 +83,13 @@ export default class PlayerArms {
   startSway() {
     this.baseLeftRotX = this.leftUpper.rotation.x
     this.baseRightRotX = this.rightUpper.rotation.x
-    this.baseLeftRotZ = this.leftUpper.rotation.z
-    this.baseRightRotZ = this.rightUpper.rotation.z
   }
 
   sway(t: number) {
     const swing = Math.sin(t * Math.PI)
     const ampX = 0.1
-    const ampZ = 0.05
     this.leftUpper.rotation.x = this.baseLeftRotX + swing * ampX
-    this.rightUpper.rotation.x =
-      this.baseRightRotX + Math.sin(t * Math.PI + Math.PI / 2) * ampX
-    this.leftUpper.rotation.z =
-      this.baseLeftRotZ + Math.sin(t * Math.PI + Math.PI / 2) * ampZ
-    this.rightUpper.rotation.z = this.baseRightRotZ - swing * ampZ
+    this.rightUpper.rotation.x = this.baseRightRotX - swing * ampX
   }
 
   getSettings() {

--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -12,6 +12,10 @@ export default class PlayerArms {
   private spacing = 0.4
   private lowerDist = -0.06
   private fistDist = 0
+  private baseLeftRotX = 0
+  private baseRightRotX = 0
+  private baseLeftRotZ = 0
+  private baseRightRotZ = 0
 
   constructor(camera: THREE.Camera) {
     this.group = new THREE.Group()
@@ -76,6 +80,25 @@ export default class PlayerArms {
     this.group.add(this.rightUpper)
     this.group.position.y = -0.6
     camera.add(this.group)
+  }
+
+  startSway() {
+    this.baseLeftRotX = this.leftUpper.rotation.x
+    this.baseRightRotX = this.rightUpper.rotation.x
+    this.baseLeftRotZ = this.leftUpper.rotation.z
+    this.baseRightRotZ = this.rightUpper.rotation.z
+  }
+
+  sway(t: number) {
+    const swing = Math.sin(t * Math.PI)
+    const ampX = 0.1
+    const ampZ = 0.05
+    this.leftUpper.rotation.x = this.baseLeftRotX + swing * ampX
+    this.rightUpper.rotation.x =
+      this.baseRightRotX + Math.sin(t * Math.PI + Math.PI / 2) * ampX
+    this.leftUpper.rotation.z =
+      this.baseLeftRotZ + Math.sin(t * Math.PI + Math.PI / 2) * ampZ
+    this.rightUpper.rotation.z = this.baseRightRotZ - swing * ampZ
   }
 
   getSettings() {

--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -87,7 +87,7 @@ export default class PlayerArms {
 
   sway(t: number) {
     const swing = Math.sin(t * Math.PI)
-    const ampY = 0.1
+    const ampY = 0.03
     this.leftUpper.position.y = this.baseLeftY + swing * ampY
     this.rightUpper.position.y = this.baseRightY - swing * ampY
   }


### PR DESCRIPTION
## Summary
- animate arms when the player moves or turns
- capture base arm rotation at the start of each movement
- sway each arm in different phases during the camera transition

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e1d38344c8333916e2799aa750a9c