### PR TITLE
Adjust player height and camera

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -46,6 +46,8 @@ export default class DungeonView3D {
   private readonly animDuration = 200 // ms
   private arms: PlayerArms
   private readonly cellSize = 2
+  private readonly playerHeight = this.cellSize * 2
+  private readonly eyeLevel = this.playerHeight - 0.4
   private readonly wallNoiseScale = 25
 
   constructor(
@@ -128,7 +130,7 @@ export default class DungeonView3D {
     const h0 = this.map.getHeight(this.player.x, this.player.y) * this.cellSize
     this.camera.position.set(
       this.player.x * this.cellSize + this.cellSize / 2,
-      h0 + 1.6,
+      h0 + this.eyeLevel,
       this.player.y * this.cellSize + this.cellSize / 2
     )
     this.camera.rotation.set(0, this.angleForDir(this.player.dir), 0)
@@ -285,7 +287,7 @@ export default class DungeonView3D {
     const th = this.map.getHeight(this.player.x, this.player.y) * this.cellSize
     this.torch.position.set(
       this.player.x * this.cellSize + this.cellSize / 2,
-      th + 1.6,
+      th + this.eyeLevel,
       this.player.y * this.cellSize + this.cellSize / 2
     )
     const light = new THREE.PointLight(0xffaa00, 1, 5)
@@ -512,7 +514,8 @@ export default class DungeonView3D {
     this.startRot = this.camera.rotation.y
     this.targetPos.set(
       this.player.x * this.cellSize + this.cellSize / 2,
-      this.map.getHeight(this.player.x, this.player.y) * this.cellSize + 1.6,
+      this.map.getHeight(this.player.x, this.player.y) * this.cellSize +
+        this.eyeLevel,
       this.player.y * this.cellSize + this.cellSize / 2
     )
     this.targetRot = this.angleForDir(this.player.dir)


### PR DESCRIPTION
## Summary
- increase player height to 2 cells
- set camera and torch Y positions relative to new height

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e222887f48333a528657cd81ff52a