### PR TITLE
Implement ADSR envelope and shimmering forest biome

### DIFF
--- a/src/audio/AmbientMusicGenerator.ts
+++ b/src/audio/AmbientMusicGenerator.ts
@@ -43,6 +43,10 @@ export default class AmbientMusicGenerator {
     this.chordIntervalMs = intervalMs
   }
 
+  setNoteDuration(time: number) {
+    this.noteDuration = Math.max(0, time)
+  }
+
   setIntensity(level: number) {
     this.intensity = Math.max(0, Math.min(1, level))
     this.chordIntervalMs = Math.max(800, 4000 - 3200 * this.intensity)

--- a/src/audio/AmbientMusicGenerator.ts
+++ b/src/audio/AmbientMusicGenerator.ts
@@ -9,7 +9,8 @@ export default class AmbientMusicGenerator {
   ]
   private midTermProgression = [0, 5, -3, 7]
   private chordIntervalMs = 4000
-  private noteDuration = 8
+  // note value (sustain length) in seconds
+  private noteValue = 8
   private intensity = 0
 
   private chordCount = 0
@@ -43,14 +44,17 @@ export default class AmbientMusicGenerator {
     this.chordIntervalMs = intervalMs
   }
 
-  setNoteDuration(time: number) {
-    this.noteDuration = Math.max(0, time)
+  /**
+   * Adjust note value (sustain length).
+   */
+  setNoteValue(time: number) {
+    this.noteValue = Math.max(0, time)
   }
 
   setIntensity(level: number) {
     this.intensity = Math.max(0, Math.min(1, level))
     this.chordIntervalMs = Math.max(800, 4000 - 3200 * this.intensity)
-    this.noteDuration = Math.max(4, 8 - 4 * this.intensity)
+    this.noteValue = Math.max(4, 8 - 4 * this.intensity)
   }
 
   start() {
@@ -71,7 +75,7 @@ export default class AmbientMusicGenerator {
     const steps = [0, 2, 4, 2]
     for (const s of steps) {
       const freq = this.root * Math.pow(2, s / 12)
-      this.synth.playNote(freq, this.noteDuration)
+      this.synth.playNote(freq, this.noteValue)
       await this.wait(this.chordIntervalMs)
     }
     this.synth.setMasterGain(this.defaultGain, fadeSec)
@@ -98,7 +102,7 @@ export default class AmbientMusicGenerator {
     for (const d of degrees) {
       const semitone = scale[(rootIndex + d) % scale.length]
       const freq = base * Math.pow(2, semitone / 12)
-      this.synth.playNote(freq, this.noteDuration)
+      this.synth.playNote(freq, this.noteValue)
     }
 
     this.chordCount++

--- a/src/audio/AmbientPadSynth.ts
+++ b/src/audio/AmbientPadSynth.ts
@@ -1,4 +1,4 @@
-export type AmbientPatch = 'saw' | 'triangle' | 'square' | 'noise'
+export type AmbientPatch = 'saw' | 'triangle' | 'square' | 'noise' | 'woodbass'
 
 export interface ADSR {
   attack: number
@@ -49,9 +49,11 @@ export default class AmbientPadSynth {
 
   /**
    * Change the current timbre patch.
-   */
+  */
   setPatch(patch: AmbientPatch | AmbientPatch[]) {
     this.patches = Array.isArray(patch) ? patch : [patch]
+    // use a lower filter cutoff when woodbass is included
+    this.filter.frequency.value = this.patches.includes('woodbass') ? 600 : 800
   }
 
   /**
@@ -99,6 +101,22 @@ export default class AmbientPadSynth {
         src.connect(gain)
         src.start(now)
         src.stop(releaseStart + release)
+        continue
+      }
+
+      if (patch === 'woodbass') {
+        const osc = this.ctx.createOscillator()
+        osc.type = 'sawtooth'
+        osc.frequency.value = freq
+        osc.connect(gain)
+        const sub = this.ctx.createOscillator()
+        sub.type = 'sine'
+        sub.frequency.value = freq / 2
+        sub.connect(gain)
+        osc.start(now)
+        sub.start(now)
+        osc.stop(releaseStart + release)
+        sub.stop(releaseStart + release)
         continue
       }
 

--- a/src/audio/ambient.ts
+++ b/src/audio/ambient.ts
@@ -16,14 +16,14 @@ const biomeConfigs: Record<string, {
   noteLength?: number
 }> = {
   forest: {
-    patch: ['triangle', 'saw'],
+    patch: ['triangle', 'saw', 'woodbass'],
     scales: [[0, 2, 5, 7, 9], [0, 4, 5, 7, 11]],
     root: 220,
     noise: 0.05,
     decay: 12,
     intensity: 0.3,
     envelope: { attack: 0.5, decay: 0.2, sustain: 0.8, release: 12 },
-    noteLength: 0.5
+    noteLength: 0.3
   },
   cave: {
     patch: 'noise',
@@ -55,7 +55,7 @@ export async function setAmbientBiome(name: string, bridge = true) {
   generator.setRoot(cfg.root)
   synth.setNoiseLevel(cfg.noise)
   synth.setDecay(cfg.decay)
-  if (cfg.noteLength !== undefined) generator.setNoteDuration(cfg.noteLength)
+  if (cfg.noteLength !== undefined) generator.setNoteValue(cfg.noteLength)
   generator.setIntensity(cfg.intensity)
   synth.setMasterGain(0.03, 15)
   generator.start()

--- a/src/audio/ambient.ts
+++ b/src/audio/ambient.ts
@@ -23,7 +23,7 @@ const biomeConfigs: Record<string, {
     decay: 12,
     intensity: 0.3,
     envelope: { attack: 0.5, decay: 0.2, sustain: 0.8, release: 12 },
-    noteLength: 0.3
+    noteLength: 0.2
   },
   cave: {
     patch: 'noise',
@@ -55,8 +55,8 @@ export async function setAmbientBiome(name: string, bridge = true) {
   generator.setRoot(cfg.root)
   synth.setNoiseLevel(cfg.noise)
   synth.setDecay(cfg.decay)
-  if (cfg.noteLength !== undefined) generator.setNoteValue(cfg.noteLength)
   generator.setIntensity(cfg.intensity)
+  if (cfg.noteLength !== undefined) generator.setNoteValue(cfg.noteLength)
   synth.setMasterGain(0.03, 15)
   generator.start()
 }


### PR DESCRIPTION
## Summary
- enhance `AmbientPadSynth` with ADSR envelope support and multiple patches
- allow `AmbientMusicGenerator` to adjust note duration
- update ambient biome configuration so the forest uses layered patches with long releases

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e35b017d88333ba8695441a18a10e