### PR TITLE
Add debug mode for assets

### DIFF
--- a/src/tabs/debug.ts
+++ b/src/tabs/debug.ts
@@ -1,0 +1,110 @@
+import * as THREE from 'three'
+import BlockyCharacterLoader from '../games/dungeon-rpg-three/components/BlockyCharacterLoader'
+import sound from '../audio'
+
+export default function showDebug(
+  container: HTMLElement,
+  loadTab: (tab: 'top') => void
+) {
+  container.innerHTML = `
+    <button id="back-to-top" style="position:absolute;z-index:1000;top:10px;left:10px;">トップへ戻る</button>
+    <div id="viewer" style="width:100%;height:100%;"></div>
+    <div id="controls" style="position:absolute;z-index:1000;bottom:10px;left:50%;transform:translateX(-50%);background:rgba(255,255,255,0.8);padding:4px;display:flex;gap:4px;">
+      <select id="char-select"></select>
+      <button id="rot-left">⟲</button>
+      <button id="rot-right">⟳</button>
+      <button id="zoom-in">＋</button>
+      <button id="zoom-out">－</button>
+      <button id="play-bgm">BGM</button>
+      <button id="stop-bgm">BGM停止</button>
+      <button id="play-se">効果音</button>
+    </div>
+  `
+  container.style.position = 'relative'
+  container.style.background =
+    'repeating-conic-gradient(#888 0% 25%, #444 0% 50%) 0/40px 40px'
+  const back = container.querySelector('#back-to-top') as HTMLButtonElement
+  back.addEventListener('click', () => loadTab('top'))
+
+  const viewer = container.querySelector('#viewer') as HTMLDivElement
+  const select = container.querySelector('#char-select') as HTMLSelectElement
+  const rotL = container.querySelector('#rot-left') as HTMLButtonElement
+  const rotR = container.querySelector('#rot-right') as HTMLButtonElement
+  const zoomIn = container.querySelector('#zoom-in') as HTMLButtonElement
+  const zoomOut = container.querySelector('#zoom-out') as HTMLButtonElement
+  const playBgm = container.querySelector('#play-bgm') as HTMLButtonElement
+  const stopBgm = container.querySelector('#stop-bgm') as HTMLButtonElement
+  const playSe = container.querySelector('#play-se') as HTMLButtonElement
+
+  const characters = [
+    {
+      name: 'Blocky Doll',
+      url: new URL('../assets/characters/blocky-doll.json', import.meta.url).href,
+    },
+    {
+      name: 'Skeleton Warrior',
+      url: new URL('../assets/enemies/json/skeleton-warrior-blocky.json', import.meta.url).href,
+    },
+  ]
+  characters.forEach((c) => {
+    const opt = document.createElement('option')
+    opt.value = c.url
+    opt.textContent = c.name
+    select.appendChild(opt)
+  })
+
+  const renderer = new THREE.WebGLRenderer()
+  viewer.appendChild(renderer.domElement)
+  const scene = new THREE.Scene()
+  const camera = new THREE.PerspectiveCamera(45, 2, 0.1, 100)
+  camera.position.set(0, 1.5, 5)
+  scene.add(new THREE.AmbientLight(0xffffff, 0.8))
+  const light = new THREE.DirectionalLight(0xffffff, 1)
+  light.position.set(2, 3, 2)
+  scene.add(light)
+  let model: THREE.Group | null = null
+
+  async function load(url: string) {
+    const loader = new BlockyCharacterLoader(url)
+    const obj = await loader.load()
+    if (model) scene.remove(model)
+    model = obj
+    scene.add(model)
+  }
+  load(select.value)
+  select.addEventListener('change', () => load(select.value))
+
+  let rot = 0
+  rotL.addEventListener('click', () => {
+    rot -= 0.1
+  })
+  rotR.addEventListener('click', () => {
+    rot += 0.1
+  })
+  zoomIn.addEventListener('click', () => {
+    camera.position.z = Math.max(1, camera.position.z - 0.5)
+  })
+  zoomOut.addEventListener('click', () => {
+    camera.position.z += 0.5
+  })
+  playBgm.addEventListener('click', () => sound.playBgm('main'))
+  stopBgm.addEventListener('click', () => sound.stopBgm('main'))
+  playSe.addEventListener('click', () => sound.playSe('beep'))
+
+  function resize() {
+    const w = viewer.clientWidth
+    const h = viewer.clientHeight
+    renderer.setSize(w, h)
+    camera.aspect = w / h
+    camera.updateProjectionMatrix()
+  }
+  window.addEventListener('resize', resize)
+  resize()
+
+  function animate() {
+    requestAnimationFrame(animate)
+    if (model) model.rotation.y = rot
+    renderer.render(scene, camera)
+  }
+  animate()
+}

--- a/src/tabs/main.ts
+++ b/src/tabs/main.ts
@@ -2,7 +2,7 @@ import { startAmbientBgm } from '../audio/ambient'
 
 const content = document.getElementById('content') as HTMLElement
 
-type Tab = 'top' | 'novel' | 'game'
+type Tab = 'top' | 'novel' | 'game' | 'debug'
 
 async function loadTab(tab: Tab) {
   // update location hash so reloading the page keeps the current tab
@@ -17,6 +17,9 @@ async function loadTab(tab: Tab) {
   } else if (tab === 'game') {
     const { default: initGame } = await import('../games/dungeon-rpg-three/initGame')
     initGame(content, loadTab)
+  } else if (tab === 'debug') {
+    const { default: showDebug } = await import('./debug')
+    showDebug(content, loadTab)
   }
 }
 

--- a/src/tabs/main.ts
+++ b/src/tabs/main.ts
@@ -1,5 +1,3 @@
-import { startAmbientBgm } from '../audio/ambient'
-
 const content = document.getElementById('content') as HTMLElement
 
 type Tab = 'top' | 'novel' | 'game' | 'debug'
@@ -27,5 +25,3 @@ async function loadTab(tab: Tab) {
 const initialTab = (location.hash.replace('#', '') as Tab) || 'top';
 loadTab(initialTab);
 
-// start ambient background music
-startAmbientBgm().catch(console.error)

--- a/src/tabs/top.ts
+++ b/src/tabs/top.ts
@@ -1,19 +1,20 @@
 export default function showTop(
   container: HTMLElement,
-  loadTab: (tab: 'novel' | 'game') => void
+  loadTab: (tab: 'novel' | 'game' | 'debug') => void
 ) {
   container.innerHTML = `
     <header>牧野大寧公式サイト</header>
     <div class="tiles">
       <div class="tile" data-tab="novel">小説</div>
       <div class="tile" data-tab="game">ビデオゲーム</div>
+      <div class="tile" data-tab="debug">デバッグ</div>
     </div>
     <footer>&copy; 牧野大寧</footer>
   `;
   const tiles = container.querySelectorAll('.tile');
   tiles.forEach((tile) => {
     tile.addEventListener('click', () => {
-      const tab = (tile as HTMLElement).dataset.tab as 'novel' | 'game';
+      const tab = (tile as HTMLElement).dataset.tab as 'novel' | 'game' | 'debug';
       loadTab(tab);
     });
   });


### PR DESCRIPTION
## Summary
- add a new `debug` tab that displays characters and lets you play sounds
- link to the new debug mode from the top page
- load the debug tab from the main script

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e3692f4588333b82605f71b111027