### PR TITLE
Implement item grabbing with player hands

### DIFF
--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -168,4 +168,18 @@ export default class PlayerArms {
       this.rightFist.position.y = this.fistDist
     }
   }
+
+  attachItem(item: THREE.Object3D, left: boolean) {
+    const fist = left ? this.leftFist : this.rightFist
+    fist.add(item)
+    item.position.set(0, 0.1, 0)
+  }
+
+  detachItem(left: boolean): THREE.Object3D | null {
+    const fist = left ? this.leftFist : this.rightFist
+    if (fist.children.length === 0) return null
+    const obj = fist.children[fist.children.length - 1] as THREE.Object3D
+    fist.remove(obj)
+    return obj
+  }
 }


### PR DESCRIPTION
## Summary
- support attaching items to fists via PlayerArms
- track simple pickup items in `DungeonView3D`
- spawn example item and grab it when hand action performed

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e36de601c8333ae0945cc25f87461