### PR TITLE
Add player arm animation docs and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ following biomes are defined:
 
 Additional systems like weather effects are planned but not yet implemented.
 
+## Documentation
+
+- [Character Animation Design](docs/character-animation.md)
+- [Player Arm Animation Guide](docs/arm-animation.md)
+

--- a/docs/arm-animation.md
+++ b/docs/arm-animation.md
@@ -1,0 +1,59 @@
+# Player Arm Animation Guide
+
+This project includes a `PlayerArms` component that renders the hero's arms in
+first‑person view. To create reusable animations for the arms, keyframes can be
+stored in JSON files and loaded at runtime.
+
+## Joints
+
+`PlayerArms` exposes its internal meshes with the following joint names:
+
+- `leftUpperArm`
+- `leftLowerArm`
+- `leftHand`
+- `rightUpperArm`
+- `rightLowerArm`
+- `rightHand`
+
+These identifiers are used in animation keyframes.
+
+## Keyframe Format
+
+Arm animations are described by an array of keyframes. Each keyframe includes a
+`time` in milliseconds and optional transforms for any joints.
+
+```json
+[
+  {
+    "time": 0,
+    "joints": {
+      "leftUpperArm": { "rotation": [2.5, 0, 0] }
+    }
+  }
+]
+```
+
+Transforms can specify `position`, `rotation`, and `scale` as three element
+arrays. Rotations are expressed in radians.
+
+Keyframes are loaded with `loadKeyframes()` and played using the generic
+`Animator` class.
+
+## Example
+
+1. Place JSON files under `src/assets/arms/animations/`.
+2. Load the keyframes:
+
+```ts
+import Animator from '../animation/Animator'
+import { loadKeyframes } from '../animation/loadKeyframes'
+import PlayerArms from './PlayerArms'
+
+const arms = new PlayerArms(camera)
+const keyframes = await loadKeyframes('assets/arms/animations/raise_hands.json')
+const animator = new Animator(arms.getJoints(), keyframes)
+animator.play()
+```
+
+This design allows new motions—such as waving, raising both hands or grabbing
+objects—to be authored in JSON without changing code.

--- a/src/assets/arms/animations/raise_hands.json
+++ b/src/assets/arms/animations/raise_hands.json
@@ -1,0 +1,23 @@
+[
+  {
+    "time": 0,
+    "joints": {
+      "leftUpperArm": { "rotation": [2.5, 0, 0] },
+      "rightUpperArm": { "rotation": [2.5, 0, 0] }
+    }
+  },
+  {
+    "time": 250,
+    "joints": {
+      "leftUpperArm": { "rotation": [1.0, 0, 0] },
+      "rightUpperArm": { "rotation": [1.0, 0, 0] }
+    }
+  },
+  {
+    "time": 500,
+    "joints": {
+      "leftUpperArm": { "rotation": [0, 0, 0] },
+      "rightUpperArm": { "rotation": [0, 0, 0] }
+    }
+  }
+]

--- a/src/games/animation/loadKeyframes.ts
+++ b/src/games/animation/loadKeyframes.ts
@@ -1,0 +1,27 @@
+import * as THREE from 'three'
+import { Keyframe, JointTransform } from './Animator'
+
+export interface KeyframeJSON {
+  time: number
+  joints: Record<string, {
+    position?: [number, number, number]
+    rotation?: [number, number, number]
+    scale?: [number, number, number]
+  }>
+}
+
+export async function loadKeyframes(url: string): Promise<Keyframe[]> {
+  const resp = await fetch(url)
+  const data: KeyframeJSON[] = await resp.json()
+  return data.map((kf) => {
+    const joints: Record<string, JointTransform> = {}
+    for (const [name, t] of Object.entries(kf.joints)) {
+      const jt: JointTransform = {}
+      if (t.position) jt.position = new THREE.Vector3(...t.position)
+      if (t.rotation) jt.rotation = new THREE.Euler(...t.rotation)
+      if (t.scale) jt.scale = new THREE.Vector3(...t.scale)
+      joints[name] = jt
+    }
+    return { time: kf.time, joints }
+  })
+}

--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -121,6 +121,21 @@ export default class PlayerArms {
     }
   }
 
+  /**
+   * Expose the internal arm meshes so they can be animated using
+   * the generic {@link Animator} class.
+   */
+  getJoints() {
+    return {
+      leftUpperArm: this.leftUpper,
+      leftLowerArm: this.leftLower,
+      leftHand: this.leftFist,
+      rightUpperArm: this.rightUpper,
+      rightLowerArm: this.rightLower,
+      rightHand: this.rightFist,
+    }
+  }
+
   update(settings: {
     posY?: number
     upperRotX?: number


### PR DESCRIPTION
## Summary
- document how to create player arm animations
- expose joints from `PlayerArms` for generic animations
- provide JSON keyframe loader and sample animation
- link new docs from README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e3fb292608333b2ffb500b0a91c0a