### PR TITLE
Add draggable debug overlay window

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -704,8 +704,15 @@ export default class DungeonView3D {
 
   getDetailedDebug(): string {
     const lines: string[] = []
-    lines.push(`Player: (${this.player.x.toFixed(2)}, ${this.player.y.toFixed(2)}) Dir:${this.player.dir}`)
-    lines.push(`HP:${this.hero.hp} Hunger:${this.hero.hunger} Stamina:${this.hero.stamina}`)
+    lines.push(
+      `Player: (${this.player.x.toFixed(2)}, ${this.player.y.toFixed(2)}) Dir:${
+        this.player.dir}`,
+    )
+    lines.push(
+      `HP:${this.hero.hp} Hunger:${this.hero.hunger} Stamina:${this.hero.stamina}`,
+    )
+    const footH = this.map.getHeight(this.player.x, this.player.y)
+    lines.push(`Foot height: ${footH}`)
     lines.push('Around:')
     for (let dy = -1; dy <= 1; dy++) {
       for (let dx = -1; dx <= 1; dx++) {
@@ -714,7 +721,11 @@ export default class DungeonView3D {
         const y = Math.floor(this.player.y) + dy
         const tile = this.map.tileAt(x, y)
         const enemy = this.enemies.find((e) => e.x === x && e.y === y)
-        lines.push(`(${x},${y}) ${tile} ${enemy ? enemy.enemy.name : ''}`)
+        const voxel = this.map.voxelAt(x, y, footH - 1)
+        const voxelName = voxel !== null ? voxel : 'null'
+        lines.push(
+          `(${x},${y}) ${tile} ${voxelName} ${enemy ? enemy.enemy.name : ''}`,
+        )
       }
     }
     lines.push(`Map ${this.map.width}x${this.map.height}`)

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -697,4 +697,27 @@ export default class DungeonView3D {
       `Enemies: ${enemyInfo}`
     )
   }
+
+  getHero() {
+    return this.hero
+  }
+
+  getDetailedDebug(): string {
+    const lines: string[] = []
+    lines.push(`Player: (${this.player.x.toFixed(2)}, ${this.player.y.toFixed(2)}) Dir:${this.player.dir}`)
+    lines.push(`HP:${this.hero.hp} Hunger:${this.hero.hunger} Stamina:${this.hero.stamina}`)
+    lines.push('Around:')
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (dx === 0 && dy === 0) continue
+        const x = Math.floor(this.player.x) + dx
+        const y = Math.floor(this.player.y) + dy
+        const tile = this.map.tileAt(x, y)
+        const enemy = this.enemies.find((e) => e.x === x && e.y === y)
+        lines.push(`(${x},${y}) ${tile} ${enemy ? enemy.enemy.name : ''}`)
+      }
+    }
+    lines.push(`Map ${this.map.width}x${this.map.height}`)
+    return lines.join('\n')
+  }
 }

--- a/src/games/dungeon-rpg-three/initGame.ts
+++ b/src/games/dungeon-rpg-three/initGame.ts
@@ -7,31 +7,88 @@ export default function initThreeGame(
 ) {
   container.innerHTML = `
     <button id="back-to-top" style="position:absolute;z-index:1000;top:10px;left:10px;">トップへ戻る</button>
-    <canvas id="mini-map" width="150" height="150" style="position:absolute;z-index:500;top:10px;right:10px;border:1px solid #000"></canvas>
-    <div id="status-display" style="position:absolute;z-index:700;top:10px;left:50%;transform:translateX(-50%);font-size:24px;color:#fff;text-shadow:0 0 2px #000"></div>
-    <div id="debug-info" style="position:absolute;z-index:800;bottom:10px;left:10px;padding:4px;background:rgba(0,0,0,0.5);color:#fff;font:12px monospace;white-space:pre;"></div>
-    <div id="arm-controls" style="position:absolute;z-index:600;top:10px;right:170px;padding:4px;background:rgba(0,0,0,0.5);color:#fff;font:12px monospace;">
-      <div>PosY <input id="arm-pos-y" type="range" min="-1.2" max="0" step="0.01"></div>
-      <div>Upper X <input id="arm-upper-x" type="range" min="-3.14" max="3.14" step="0.01"></div>
-      <div>Lower X <input id="arm-lower-x" type="range" min="-3.14" max="3.14" step="0.01"></div>
-      <div>Rot Z <input id="arm-rot-z" type="range" min="-1.57" max="1.57" step="0.01"></div>
-      <div>Scale <input id="arm-scale" type="range" min="0.3" max="2" step="0.01"></div>
-      <div>Spacing <input id="arm-spacing" type="range" min="0" max="1" step="0.01"></div>
-      <div>Lower Dist <input id="arm-lower-dist" type="range" min="-1" max="0" step="0.01"></div>
-      <div>Fist Dist <input id="arm-fist-dist" type="range" min="-1" max="0" step="0.01"></div>
-      <button id="arm-copy">copy</button>
-    </div>
     <div id="three-game" style="width:100%;height:100%"></div>
+    <div id="debug-overlay" style="display:none;position:absolute;z-index:900;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);">
+      <div id="debug-window" style="position:absolute;top:20px;left:20px;background:rgba(0,0,0,0.8);padding:10px;color:#fff;cursor:move;">
+        <div id="status-display" style="font-size:24px;text-shadow:0 0 2px #000"></div>
+        <pre id="debug-info" style="font:12px monospace;white-space:pre;"></pre>
+        <canvas id="mini-map" width="150" height="150" style="margin-top:10px;border:1px solid #000"></canvas>
+        <div id="arm-controls" style="margin-top:10px;background:rgba(0,0,0,0.5);padding:4px;font:12px monospace;">
+          <div>PosY <input id="arm-pos-y" type="range" min="-1.2" max="0" step="0.01"></div>
+          <div>Upper X <input id="arm-upper-x" type="range" min="-3.14" max="3.14" step="0.01"></div>
+          <div>Lower X <input id="arm-lower-x" type="range" min="-3.14" max="3.14" step="0.01"></div>
+          <div>Rot Z <input id="arm-rot-z" type="range" min="-1.57" max="1.57" step="0.01"></div>
+          <div>Scale <input id="arm-scale" type="range" min="0.3" max="2" step="0.01"></div>
+          <div>Spacing <input id="arm-spacing" type="range" min="0" max="1" step="0.01"></div>
+          <div>Lower Dist <input id="arm-lower-dist" type="range" min="-1" max="0" step="0.01"></div>
+          <div>Fist Dist <input id="arm-fist-dist" type="range" min="-1" max="0" step="0.01"></div>
+          <button id="arm-copy">copy</button>
+        </div>
+        <div id="hero-controls" style="margin-top:10px;font:12px monospace;">
+          <div>HP <input id="hero-hp" type="number" style="width:60px;"></div>
+          <div>Hunger <input id="hero-hunger" type="number" style="width:60px;"></div>
+          <div>Stamina <input id="hero-stamina" type="number" style="width:60px;"></div>
+        </div>
+      </div>
+    </div>
   `
   const back = container.querySelector('#back-to-top') as HTMLButtonElement
   back.addEventListener('click', () => loadTab('top'))
 
   const wrapper = container.querySelector('#three-game') as HTMLElement
+  const overlay = container.querySelector('#debug-overlay') as HTMLDivElement
+  const debugWin = container.querySelector('#debug-window') as HTMLDivElement
   const miniMap = container.querySelector('#mini-map') as HTMLCanvasElement
   const statusDiv = container.querySelector('#status-display') as HTMLDivElement
-  const debugDiv = container.querySelector('#debug-info') as HTMLDivElement
+  const debugDiv = container.querySelector('#debug-info') as HTMLPreElement
+  const heroControls = container.querySelector('#hero-controls') as HTMLDivElement
+  const heroHp = heroControls.querySelector('#hero-hp') as HTMLInputElement
+  const heroHunger = heroControls.querySelector('#hero-hunger') as HTMLInputElement
+  const heroStamina = heroControls.querySelector('#hero-stamina') as HTMLInputElement
   container.style.position = 'relative'
   const view = new DungeonView3D(wrapper, miniMap, forestBiome)
+
+  heroHp.value = view.getHero().hp.toString()
+  heroHunger.value = view.getHero().hunger.toString()
+  heroStamina.value = view.getHero().stamina.toString()
+
+  function updateHero() {
+    const hero = view.getHero()
+    hero.hp = parseInt(heroHp.value)
+    hero.hunger = parseInt(heroHunger.value)
+    hero.stamina = parseInt(heroStamina.value)
+  }
+  ;[heroHp, heroHunger, heroStamina].forEach((i) => i.addEventListener('input', updateHero))
+
+  let dragging = false
+  let offsetX = 0
+  let offsetY = 0
+  debugWin.addEventListener('mousedown', (e) => {
+    dragging = true
+    offsetX = e.offsetX
+    offsetY = e.offsetY
+  })
+  window.addEventListener('mousemove', (e) => {
+    if (!dragging) return
+    debugWin.style.left = `${e.clientX - offsetX}px`
+    debugWin.style.top = `${e.clientY - offsetY}px`
+  })
+  window.addEventListener('mouseup', () => {
+    dragging = false
+  })
+
+  function toggleOverlay() {
+    overlay.style.display = overlay.style.display === 'none' ? 'block' : 'none'
+  }
+  window.addEventListener('keydown', (e) => {
+    if (e.key.toLowerCase() === 'p') {
+      e.preventDefault()
+      toggleOverlay()
+    }
+  })
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) toggleOverlay()
+  })
 
   const armControls = container.querySelector('#arm-controls') as HTMLDivElement
   const posY = armControls.querySelector('#arm-pos-y') as HTMLInputElement
@@ -77,7 +134,7 @@ export default function initThreeGame(
     view.update()
     view.render()
     if (debugDiv) {
-      debugDiv.textContent = view.getDebugText()
+      debugDiv.textContent = view.getDetailedDebug()
     }
     if (statusDiv) {
       statusDiv.innerHTML = view.getStatusHTML()

--- a/src/games/dungeon-rpg-three/initGame.ts
+++ b/src/games/dungeon-rpg-three/initGame.ts
@@ -9,12 +9,14 @@ export default function initThreeGame(
     <button id="back-to-top" style="position:absolute;z-index:1000;top:10px;left:10px;">トップへ戻る</button>
     <div id="three-game" style="width:100%;height:100%"></div>
     <div id="debug-overlay" style="display:none;position:absolute;z-index:900;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);">
-      <div id="debug-window" style="position:absolute;top:20px;left:20px;background:rgba(0,0,0,0.8);padding:10px;color:#fff;cursor:move;">
-        <div id="status-display" style="font-size:24px;text-shadow:0 0 2px #000"></div>
-        <pre id="debug-info" style="font:12px monospace;white-space:pre;"></pre>
-        <canvas id="mini-map" width="150" height="150" style="margin-top:10px;border:1px solid #000"></canvas>
-        <div id="arm-controls" style="margin-top:10px;background:rgba(0,0,0,0.5);padding:4px;font:12px monospace;">
-          <div>PosY <input id="arm-pos-y" type="range" min="-1.2" max="0" step="0.01"></div>
+      <div id="debug-window" style="position:absolute;top:20px;left:20px;background:rgba(0,0,0,0.8);padding:0;color:#fff;">
+        <div id="debug-header" style="background:#555;padding:4px;cursor:move;">Debug</div>
+        <div style="padding:10px;">
+          <div id="status-display" style="font-size:24px;text-shadow:0 0 2px #000"></div>
+          <pre id="debug-info" style="font:12px monospace;white-space:pre;"></pre>
+          <canvas id="mini-map" width="150" height="150" style="margin-top:10px;border:1px solid #000"></canvas>
+          <div id="arm-controls" style="margin-top:10px;background:rgba(0,0,0,0.5);padding:4px;font:12px monospace;">
+            <div>PosY <input id="arm-pos-y" type="range" min="-1.2" max="0" step="0.01"></div>
           <div>Upper X <input id="arm-upper-x" type="range" min="-3.14" max="3.14" step="0.01"></div>
           <div>Lower X <input id="arm-lower-x" type="range" min="-3.14" max="3.14" step="0.01"></div>
           <div>Rot Z <input id="arm-rot-z" type="range" min="-1.57" max="1.57" step="0.01"></div>
@@ -29,6 +31,7 @@ export default function initThreeGame(
           <div>Hunger <input id="hero-hunger" type="number" style="width:60px;"></div>
           <div>Stamina <input id="hero-stamina" type="number" style="width:60px;"></div>
         </div>
+        </div>
       </div>
     </div>
   `
@@ -38,6 +41,7 @@ export default function initThreeGame(
   const wrapper = container.querySelector('#three-game') as HTMLElement
   const overlay = container.querySelector('#debug-overlay') as HTMLDivElement
   const debugWin = container.querySelector('#debug-window') as HTMLDivElement
+  const debugHeader = container.querySelector('#debug-header') as HTMLDivElement
   const miniMap = container.querySelector('#mini-map') as HTMLCanvasElement
   const statusDiv = container.querySelector('#status-display') as HTMLDivElement
   const debugDiv = container.querySelector('#debug-info') as HTMLPreElement
@@ -63,10 +67,10 @@ export default function initThreeGame(
   let dragging = false
   let offsetX = 0
   let offsetY = 0
-  debugWin.addEventListener('mousedown', (e) => {
+  debugHeader.addEventListener('mousedown', (e) => {
     dragging = true
-    offsetX = e.offsetX
-    offsetY = e.offsetY
+    offsetX = e.clientX - debugWin.offsetLeft
+    offsetY = e.clientY - debugWin.offsetTop
   })
   window.addEventListener('mousemove', (e) => {
     if (!dragging) return


### PR DESCRIPTION
## Summary
- add draggable debug overlay interface
- allow adjusting hero stats inside overlay
- integrate mini-map and arm controls into the overlay
- expose hero object and detailed debug info from game view

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e3fa97bdc8333b4f4e22d1a785064