### PR TITLE
Add punch action and animation

### DIFF
--- a/src/assets/arms/animations/punch_left.json
+++ b/src/assets/arms/animations/punch_left.json
@@ -1,0 +1,6 @@
+[
+  { "time": 0, "joints": { "leftLowerArm": { "rotation": [0, 0, 0] } } },
+  { "time": 100, "joints": { "leftLowerArm": { "rotation": [-1.0, 0, 0] } } },
+  { "time": 200, "joints": { "leftLowerArm": { "rotation": [-2.0, 0, 0] } } },
+  { "time": 300, "joints": { "leftLowerArm": { "rotation": [0, 0, 0] } } }
+]

--- a/src/assets/arms/animations/punch_right.json
+++ b/src/assets/arms/animations/punch_right.json
@@ -1,0 +1,6 @@
+[
+  { "time": 0, "joints": { "rightLowerArm": { "rotation": [0, 0, 0] } } },
+  { "time": 100, "joints": { "rightLowerArm": { "rotation": [-1.0, 0, 0] } } },
+  { "time": 200, "joints": { "rightLowerArm": { "rotation": [-2.0, 0, 0] } } },
+  { "time": 300, "joints": { "rightLowerArm": { "rotation": [0, 0, 0] } } }
+]

--- a/src/games/dungeon-rpg-three/components/PlayerArms.ts
+++ b/src/games/dungeon-rpg-three/components/PlayerArms.ts
@@ -1,5 +1,8 @@
 import * as THREE from 'three'
 import armBox from '../../../assets/arms/arm-box.json'
+import Animator, { Keyframe } from '../../animation/Animator'
+import leftPunchData from '../../../assets/arms/animations/punch_left.json'
+import rightPunchData from '../../../assets/arms/animations/punch_right.json'
 
 export default class PlayerArms {
   private group: THREE.Group
@@ -16,6 +19,9 @@ export default class PlayerArms {
   private baseRightY = 0
   private readonly defaultLeftY: number
   private readonly defaultRightY: number
+  private animator: Animator | null = null
+  private leftPunch: Keyframe[] = leftPunchData as Keyframe[]
+  private rightPunch: Keyframe[] = rightPunchData as Keyframe[]
 
   constructor(camera: THREE.Camera) {
     this.group = new THREE.Group()
@@ -134,6 +140,18 @@ export default class PlayerArms {
       rightLowerArm: this.rightLower,
       rightHand: this.rightFist,
     }
+  }
+
+  punch(left: boolean) {
+    const frames = left ? this.leftPunch : this.rightPunch
+    this.animator = new Animator(this.getJoints(), frames, false)
+    this.animator.play()
+  }
+
+  updateAnimations() {
+    if (!this.animator) return
+    this.animator.update()
+    if (this.animator.isFinished()) this.animator = null
   }
 
   update(settings: {

--- a/src/games/dungeon-rpg/actions/Action.ts
+++ b/src/games/dungeon-rpg/actions/Action.ts
@@ -1,0 +1,8 @@
+export interface Damageable {
+  name: string
+  hp: number
+}
+
+export default interface Action {
+  execute(source: { strength: number }, target: Damageable): void
+}

--- a/src/games/dungeon-rpg/actions/PunchAction.ts
+++ b/src/games/dungeon-rpg/actions/PunchAction.ts
@@ -1,0 +1,9 @@
+import Hero from '../Hero'
+import Action, { Damageable } from './Action'
+
+export default class PunchAction implements Action {
+  execute(source: Hero, target: Damageable) {
+    const dmg = source.strength
+    target.hp = Math.max(0, target.hp - dmg)
+  }
+}


### PR DESCRIPTION
## Summary
- extend `Animator` with optional looping and finish detection
- add new `Action` interface and `PunchAction` implementation
- create punch animation keyframes for left and right arms
- animate arms when punching and update animation each frame
- apply punch damage to enemies when unarmed

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e4c9c05b8833388958fbc97160f68