### PR TITLE
Add instrument classes and music generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "vite build",
     "preview": "vite preview --config vite.config.ts --port 4173",
     "convert-svgs": "node tools/svg-to-json.mjs",
-    "test": "ts-node tests/BasicSynth.test.ts"
+    "test": "ts-node tests/BasicSynth.test.ts && ts-node tests/MusicGenerator.test.ts"
   },
   "devDependencies": {
     "three": "^0.178.0",

--- a/src/audio/BasicSynth.ts
+++ b/src/audio/BasicSynth.ts
@@ -25,6 +25,14 @@ export default class BasicSynth {
     this.gain = options.gain ?? 0.2
   }
 
+  setType(type: OscillatorType) {
+    this.type = type
+  }
+
+  setGain(gain: number) {
+    this.gain = gain
+  }
+
   play(frequency: number, duration = 1) {
     if (this.oscillator) {
       this.stop()

--- a/src/audio/MusicGenerator.ts
+++ b/src/audio/MusicGenerator.ts
@@ -1,0 +1,20 @@
+import Instrument from './instruments/Instrument'
+
+export interface NoteEvent {
+  frequency: number
+  duration: number
+}
+
+export default class MusicGenerator {
+  private instrument: Instrument
+
+  constructor(instrument: Instrument) {
+    this.instrument = instrument
+  }
+
+  playSequence(sequence: NoteEvent[]) {
+    for (const note of sequence) {
+      this.instrument.play(note.frequency, note.duration)
+    }
+  }
+}

--- a/src/audio/instruments/Instrument.ts
+++ b/src/audio/instruments/Instrument.ts
@@ -1,0 +1,28 @@
+export interface InstrumentPreset {
+  type: OscillatorType
+  gain: number
+}
+
+export default class Instrument {
+  protected synth: any
+  protected preset: InstrumentPreset
+
+  constructor(synth: any, preset: InstrumentPreset) {
+    this.synth = synth
+    this.preset = preset
+  }
+
+  play(frequency: number, duration = 1) {
+    if (typeof this.synth.setType === 'function') {
+      this.synth.setType(this.preset.type)
+    } else {
+      ;(this.synth as any).type = this.preset.type
+    }
+    if (typeof this.synth.setGain === 'function') {
+      this.synth.setGain(this.preset.gain)
+    } else {
+      ;(this.synth as any).gain = this.preset.gain
+    }
+    this.synth.play(frequency, duration)
+  }
+}

--- a/src/audio/instruments/Pad.ts
+++ b/src/audio/instruments/Pad.ts
@@ -1,0 +1,9 @@
+import BasicSynth from '../BasicSynth'
+import Instrument, { InstrumentPreset } from './Instrument'
+import { padPreset } from './presets'
+
+export default class Pad extends Instrument {
+  constructor(synth?: BasicSynth, preset: InstrumentPreset = padPreset) {
+    super(synth ?? new BasicSynth(), preset)
+  }
+}

--- a/src/audio/instruments/Piano.ts
+++ b/src/audio/instruments/Piano.ts
@@ -1,0 +1,9 @@
+import BasicSynth from '../BasicSynth'
+import Instrument, { InstrumentPreset } from './Instrument'
+import { pianoPreset } from './presets'
+
+export default class Piano extends Instrument {
+  constructor(synth?: BasicSynth, preset: InstrumentPreset = pianoPreset) {
+    super(synth ?? new BasicSynth(), preset)
+  }
+}

--- a/src/audio/instruments/presets.ts
+++ b/src/audio/instruments/presets.ts
@@ -1,0 +1,9 @@
+export const pianoPreset = {
+  type: 'triangle' as OscillatorType,
+  gain: 0.3,
+}
+
+export const padPreset = {
+  type: 'sine' as OscillatorType,
+  gain: 0.2,
+}

--- a/tests/MusicGenerator.test.ts
+++ b/tests/MusicGenerator.test.ts
@@ -1,0 +1,39 @@
+import assert from 'assert'
+import MusicGenerator from '../src/audio/MusicGenerator'
+import Piano from '../src/audio/instruments/Piano'
+import Pad from '../src/audio/instruments/Pad'
+
+class MockSynth {
+  public type: OscillatorType = 'sine'
+  public gain = 0.2
+  public played: {frequency: number; duration: number}[] = []
+  setType(type: OscillatorType) { this.type = type }
+  setGain(gain: number) { this.gain = gain }
+  play(frequency: number, duration: number) {
+    this.played.push({ frequency, duration })
+  }
+}
+
+async function run() {
+  const synth = new MockSynth()
+  const piano = new Piano(synth as any)
+  const generator = new MusicGenerator(piano)
+  generator.playSequence([
+    { frequency: 440, duration: 1 },
+    { frequency: 660, duration: 0.5 },
+  ])
+  assert.strictEqual(synth.played.length, 2, 'should play two notes')
+  assert.strictEqual(synth.type, 'triangle')
+  const padSynth = new MockSynth()
+  const pad = new Pad(padSynth as any)
+  const generator2 = new MusicGenerator(pad)
+  generator2.playSequence([{ frequency: 330, duration: 1 }])
+  assert.strictEqual(padSynth.type, 'sine')
+  assert.strictEqual(padSynth.played[0].frequency, 330)
+  console.log('MusicGenerator test passed')
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- implement BasicSynth setters for type and gain
- add `Instrument` base class and presets
- implement `Piano` and `Pad` instruments
- add `MusicGenerator` to play note sequences
- create tests for new classes
- update package.json test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e4f77fc648333ba114ad5ccebb24d