### PR TITLE
Implement initial multi-track composition

### DIFF
--- a/src/audio/MusicGenerator.ts
+++ b/src/audio/MusicGenerator.ts
@@ -5,6 +5,11 @@ export interface NoteEvent {
   duration: number
 }
 
+export interface Track {
+  instrument: Instrument
+  sequence: NoteEvent[]
+}
+
 export default class MusicGenerator {
   private instrument: Instrument
 
@@ -15,6 +20,45 @@ export default class MusicGenerator {
   playSequence(sequence: NoteEvent[]) {
     for (const note of sequence) {
       this.instrument.play(note.frequency, note.duration)
+    }
+  }
+
+  static generateFixedTracks(instruments: Instrument[]): Track[] {
+    const progression = [
+      [261.63, 329.63, 392.0],
+      [349.23, 440.0, 523.25],
+      [392.0, 493.88, 587.33],
+      [261.63, 329.63, 392.0],
+    ]
+    const rhythm = [1, 1, 1, 1]
+    const tracks: Track[] = []
+
+    if (instruments[0]) {
+      const seq: NoteEvent[] = progression.map((chord, i) => ({
+        frequency: chord[0],
+        duration: rhythm[i],
+      }))
+      tracks.push({ instrument: instruments[0], sequence: seq })
+    }
+
+    if (instruments[1]) {
+      const seq: NoteEvent[] = []
+      for (const chord of progression) {
+        for (const note of chord) {
+          seq.push({ frequency: note, duration: 0.25 })
+        }
+      }
+      tracks.push({ instrument: instruments[1], sequence: seq })
+    }
+
+    return tracks
+  }
+
+  static playTracks(tracks: Track[]) {
+    for (const track of tracks) {
+      for (const note of track.sequence) {
+        track.instrument.play(note.frequency, note.duration)
+      }
     }
   }
 }

--- a/tests/MusicGenerator.test.ts
+++ b/tests/MusicGenerator.test.ts
@@ -30,6 +30,16 @@ async function run() {
   generator2.playSequence([{ frequency: 330, duration: 1 }])
   assert.strictEqual(padSynth.type, 'sine')
   assert.strictEqual(padSynth.played[0].frequency, 330)
+
+  const padSynth2 = new MockSynth()
+  const pianoSynth2 = new MockSynth()
+  const pad2 = new Pad(padSynth2 as any)
+  const piano2 = new Piano(pianoSynth2 as any)
+  const tracks = MusicGenerator.generateFixedTracks([pad2, piano2])
+  assert.strictEqual(tracks.length, 2)
+  MusicGenerator.playTracks(tracks)
+  assert.ok(padSynth2.played.length > 0, 'pad track should play notes')
+  assert.ok(pianoSynth2.played.length > 0, 'piano track should play notes')
   console.log('MusicGenerator test passed')
 }
 


### PR DESCRIPTION
## Summary
- extend `MusicGenerator` for multi-track support
- expose `generateFixedTracks` and `playTracks`
- add tests for new multi-track generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e515d78cc8333b432467b2030bfa9