### PR TITLE
Add float mode to debug window

### DIFF
--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -57,6 +57,8 @@ export default class DungeonView3D {
   private mapCenterY = 0
   private enemyBase?: THREE.Group
   private items: { name: string; x: number; y: number; mesh: THREE.Object3D }[] = []
+  private floatMode = false
+  private floatOffset = 0
 
   constructor(
     container: HTMLElement,
@@ -141,7 +143,7 @@ export default class DungeonView3D {
     const h0 = this.map.getHeight(this.player.x, this.player.y) * this.cellSize
     this.camera.position.set(
       this.player.x * this.cellSize + this.cellSize / 2,
-      h0 + this.eyeLevel,
+      h0 + this.eyeLevel + (this.floatMode ? this.floatOffset : 0),
       this.player.y * this.cellSize + this.cellSize / 2
     )
     this.camera.rotation.set(0, this.angleForDir(this.player.dir), 0)
@@ -188,21 +190,23 @@ export default class DungeonView3D {
 
   private handleKeyDown = (e: KeyboardEvent) => {
     const key = e.key.toLowerCase()
-    if (!['w', 'a', 's', 'd', 'j', 'k', 'u', 'i'].includes(key)) return
+    if (!['w', 'a', 's', 'd', 'j', 'k', 'u', 'i', 'z', 'x'].includes(key)) return
     e.preventDefault()
     const vectors = this.dirVectors[this.player.dir]
 
     const tryMove = (dx: number, dy: number) => {
       const nx = this.player.x + dx
       const ny = this.player.y + dy
-      if (this.map.tileAt(nx, ny) === '#') return false
-      const isDiag = Math.abs(dx) === 1 && Math.abs(dy) === 1
-      if (
-        isDiag &&
-        (this.map.tileAt(this.player.x + dx, this.player.y) === '#' ||
-          this.map.tileAt(this.player.x, this.player.y + dy) === '#')
-      ) {
-        return false
+      if (!this.floatMode) {
+        if (this.map.tileAt(nx, ny) === '#') return false
+        const isDiag = Math.abs(dx) === 1 && Math.abs(dy) === 1
+        if (
+          isDiag &&
+          (this.map.tileAt(this.player.x + dx, this.player.y) === '#' ||
+            this.map.tileAt(this.player.x, this.player.y + dy) === '#')
+        ) {
+          return false
+        }
       }
       this.player.x = nx
       this.player.y = ny
@@ -226,6 +230,10 @@ export default class DungeonView3D {
       this.handleHandAction(true)
     } else if (key === 'i') {
       this.handleHandAction(false)
+    } else if (key === 'z' && this.floatMode) {
+      this.floatOffset += 0.5
+    } else if (key === 'x' && this.floatMode) {
+      this.floatOffset -= 0.5
     }
     this.updateCamera()
     this.checkRegion()
@@ -659,7 +667,7 @@ export default class DungeonView3D {
     this.targetPos.set(
       this.player.x * this.cellSize + this.cellSize / 2,
       this.map.getHeight(this.player.x, this.player.y) * this.cellSize +
-        this.eyeLevel,
+        this.eyeLevel + (this.floatMode ? this.floatOffset : 0),
       this.player.y * this.cellSize + this.cellSize / 2
     )
     this.targetRot = this.angleForDir(this.player.dir)
@@ -700,6 +708,19 @@ export default class DungeonView3D {
 
   getHero() {
     return this.hero
+  }
+
+  toggleFloatMode() {
+    this.floatMode = !this.floatMode
+    if (!this.floatMode) {
+      this.floatOffset = 0
+      this.updateCamera()
+    }
+    return this.floatMode
+  }
+
+  isFloatMode() {
+    return this.floatMode
   }
 
   getDetailedDebug(): string {

--- a/src/games/dungeon-rpg-three/initGame.ts
+++ b/src/games/dungeon-rpg-three/initGame.ts
@@ -30,6 +30,7 @@ export default function initThreeGame(
           <div>HP <input id="hero-hp" type="number" style="width:60px;"></div>
           <div>Hunger <input id="hero-hunger" type="number" style="width:60px;"></div>
           <div>Stamina <input id="hero-stamina" type="number" style="width:60px;"></div>
+          <button id="float-btn">Float: OFF</button>
         </div>
         </div>
       </div>
@@ -49,6 +50,7 @@ export default function initThreeGame(
   const heroHp = heroControls.querySelector('#hero-hp') as HTMLInputElement
   const heroHunger = heroControls.querySelector('#hero-hunger') as HTMLInputElement
   const heroStamina = heroControls.querySelector('#hero-stamina') as HTMLInputElement
+  const floatBtn = heroControls.querySelector('#float-btn') as HTMLButtonElement
   container.style.position = 'relative'
   const view = new DungeonView3D(wrapper, miniMap, forestBiome)
 
@@ -63,6 +65,10 @@ export default function initThreeGame(
     hero.stamina = parseInt(heroStamina.value)
   }
   ;[heroHp, heroHunger, heroStamina].forEach((i) => i.addEventListener('input', updateHero))
+  floatBtn.addEventListener('click', () => {
+    const on = view.toggleFloatMode()
+    floatBtn.textContent = on ? 'Float: ON' : 'Float: OFF'
+  })
 
   let dragging = false
   let offsetX = 0


### PR DESCRIPTION
## Summary
- add float mode state to `DungeonView3D`
- allow vertical motion with Z/X keys and bypass collisions in float mode
- expose `toggleFloatMode` and wire it to a new button in the debug window

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e531e7e988333bc02a03edee50832