### PR TITLE
Add hero character asset combining skeleton and arms

### DIFF
--- a/src/assets/characters/hero.json
+++ b/src/assets/characters/hero.json
@@ -1,0 +1,43 @@
+{
+  "voxelHeight": 3,
+  "parts": [
+    {
+      "name": "head",
+      "size": [0.6, 0.6, 0.6],
+      "position": [0, 1.8, 0],
+      "color": "#eeeeee"
+    },
+    {
+      "name": "body",
+      "size": [0.8, 1.0, 0.4],
+      "position": [0, 0.9, 0],
+      "color": "#dddddd"
+    },
+    {
+      "name": "leftArm",
+      "mesh": "../arms/arm-box.json",
+      "position": [-0.55, 0.9, 0],
+      "color": "#dfcbbd",
+      "scale": [1.1, 1.1, 1.1]
+    },
+    {
+      "name": "rightArm",
+      "mesh": "../arms/arm-box.json",
+      "position": [0.55, 0.9, 0],
+      "color": "#dfcbbd",
+      "scale": [1.1, 1.1, 1.1]
+    },
+    {
+      "name": "leftLeg",
+      "size": [0.2, 1.2, 0.2],
+      "position": [-0.25, -0.2, 0],
+      "color": "#dddddd"
+    },
+    {
+      "name": "rightLeg",
+      "size": [0.2, 1.2, 0.2],
+      "position": [0.25, -0.2, 0],
+      "color": "#dddddd"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- create `hero.json` that merges skeleton warrior body with player arms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e5b14854c8333a12351d8cd301e7d