### PR TITLE
Fix hero asset debug loading

### DIFF
--- a/src/assets/characters/hero.json
+++ b/src/assets/characters/hero.json
@@ -1,0 +1,43 @@
+{
+  "voxelHeight": 3,
+  "parts": [
+    {
+      "name": "head",
+      "size": [0.6, 0.6, 0.6],
+      "position": [0, 1.8, 0],
+      "color": "#eeeeee"
+    },
+    {
+      "name": "body",
+      "size": [0.8, 1.0, 0.4],
+      "position": [0, 0.9, 0],
+      "color": "#dddddd"
+    },
+    {
+      "name": "leftArm",
+      "mesh": "../arms/arm-box.json",
+      "position": [-0.55, 0.9, 0],
+      "color": "#dfcbbd",
+      "scale": [1.1, 1.1, 1.1]
+    },
+    {
+      "name": "rightArm",
+      "mesh": "../arms/arm-box.json",
+      "position": [0.55, 0.9, 0],
+      "color": "#dfcbbd",
+      "scale": [1.1, 1.1, 1.1]
+    },
+    {
+      "name": "leftLeg",
+      "size": [0.2, 1.2, 0.2],
+      "position": [-0.25, -0.2, 0],
+      "color": "#dddddd"
+    },
+    {
+      "name": "rightLeg",
+      "size": [0.2, 1.2, 0.2],
+      "position": [0.25, -0.2, 0],
+      "color": "#dddddd"
+    }
+  ]
+}

--- a/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
+++ b/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
@@ -28,7 +28,7 @@ export default class BlockyCharacterLoader {
   private material?: THREE.Material
   private textureLoader = new THREE.TextureLoader()
 
-  constructor(url: string, material?: THREE.Material) {
+  constructor(url = '', material?: THREE.Material) {
     this.url = url
     this.material = material
   }
@@ -39,17 +39,18 @@ export default class BlockyCharacterLoader {
     return this.fromSpec(spec)
   }
 
-  async fromSpec(spec: CharacterSpec): Promise<THREE.Group> {
+  async fromSpec(spec: CharacterSpec, baseUrl?: string): Promise<THREE.Group> {
     const group = new THREE.Group()
     ;(group.userData.parts ||= {})
-    const baseUrl = this.url.substring(0, this.url.lastIndexOf('/') + 1)
+    const urlBase =
+      baseUrl || this.url.substring(0, this.url.lastIndexOf('/') + 1)
     if (typeof spec.voxelHeight === 'number') {
       group.userData.voxelHeight = spec.voxelHeight
     }
     for (const p of spec.parts) {
       let geom: THREE.BufferGeometry | THREE.BoxGeometry
       if (p.mesh) {
-        const url = new URL(p.mesh, baseUrl).href
+        const url = new URL(p.mesh, urlBase).href
         const resp = await fetch(url)
         const data: { vertices: number[]; indices: number[] } = await resp.json()
         geom = new THREE.BufferGeometry()
@@ -77,7 +78,7 @@ export default class BlockyCharacterLoader {
         ;(['right', 'left', 'top', 'bottom', 'front', 'back'] as FaceDirection[]).forEach((dir) => {
           const texPath = p.textures![dir]
           if (texPath) {
-            const url = new URL(texPath, baseUrl).href
+            const url = new URL(texPath, urlBase).href
             const tex = this.textureLoader.load(url)
             materials[dirIndex[dir]] = new THREE.MeshLambertMaterial({ map: tex })
           } else {

--- a/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
+++ b/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
@@ -42,8 +42,11 @@ export default class BlockyCharacterLoader {
   async fromSpec(spec: CharacterSpec, baseUrl?: string): Promise<THREE.Group> {
     const group = new THREE.Group()
     ;(group.userData.parts ||= {})
-    const urlBase =
-      baseUrl || this.url.substring(0, this.url.lastIndexOf('/') + 1)
+    let urlBase = baseUrl || this.url.substring(0, this.url.lastIndexOf('/') + 1)
+    // ensure the base URL is valid so relative asset paths resolve correctly
+    if (!urlBase) {
+      if (typeof window !== 'undefined') urlBase = window.location.origin + '/'
+    }
     if (typeof spec.voxelHeight === 'number') {
       group.userData.voxelHeight = spec.voxelHeight
     }

--- a/src/tabs/debug.ts
+++ b/src/tabs/debug.ts
@@ -60,6 +60,7 @@ export default function showDebug(
       const baseUrl = absUrl.substring(0, absUrl.lastIndexOf('/') + 1)
       const relDir = path.slice('../assets/'.length, path.lastIndexOf('/') + 1)
       const spec: any = JSON.parse(JSON.stringify((mod as any).default))
+      if (!Array.isArray(spec.parts)) return null
       for (const part of spec.parts) {
         if (part.mesh) {
           const joined = normalizePath(relDir, part.mesh)
@@ -80,6 +81,7 @@ export default function showDebug(
       }
       return { name, spec, baseUrl }
     })
+    .filter(Boolean)
     .sort((a, b) => a.name.localeCompare(b.name))
   characters.forEach((c) => {
     const opt = document.createElement('option')

--- a/src/tabs/debug.ts
+++ b/src/tabs/debug.ts
@@ -56,8 +56,8 @@ export default function showDebug(
         .replace(/-/g, ' ')
         .replace(/\b\w/g, (c) => c.toUpperCase())
       const assetUrl = (assetUrls as Record<string, string>)[path]
-      const absUrl = new URL(assetUrl, import.meta.url).href
-      const baseUrl = absUrl.substring(0, absUrl.lastIndexOf('/') + 1)
+      const absUrl = new URL(assetUrl, import.meta.url)
+      const baseUrl = new URL('./', absUrl).href
       const relDir = path.slice('../assets/'.length, path.lastIndexOf('/') + 1)
       const spec: any = JSON.parse(JSON.stringify((mod as any).default))
       if (!Array.isArray(spec.parts)) return null

--- a/src/tabs/debug.ts
+++ b/src/tabs/debug.ts
@@ -63,7 +63,13 @@ export default function showDebug(
       } catch {
         absUrl = new URL(path, import.meta.url)
       }
-      let baseUrl = new URL('./', absUrl).href
+      let baseUrl: string
+      try {
+        baseUrl = new URL('./', absUrl).href
+      } catch {
+        const fallback = new URL(path, import.meta.url)
+        baseUrl = new URL('./', fallback).href
+      }
       if (!baseUrl) {
         if (typeof window !== 'undefined') baseUrl = window.location.origin + '/'
       }

--- a/src/tabs/debug.ts
+++ b/src/tabs/debug.ts
@@ -56,8 +56,17 @@ export default function showDebug(
         .replace(/-/g, ' ')
         .replace(/\b\w/g, (c) => c.toUpperCase())
       const assetUrl = (assetUrls as Record<string, string>)[path]
-      const absUrl = new URL(assetUrl, import.meta.url)
-      const baseUrl = new URL('./', absUrl).href
+      let absUrl: URL
+      try {
+        if (assetUrl) absUrl = new URL(assetUrl, import.meta.url)
+        else throw new Error('no asset url')
+      } catch {
+        absUrl = new URL(path, import.meta.url)
+      }
+      let baseUrl = new URL('./', absUrl).href
+      if (!baseUrl) {
+        if (typeof window !== 'undefined') baseUrl = window.location.origin + '/'
+      }
       const relDir = path.slice('../assets/'.length, path.lastIndexOf('/') + 1)
       const spec: any = JSON.parse(JSON.stringify((mod as any).default))
       if (!Array.isArray(spec.parts)) return null

--- a/src/tabs/debug.ts
+++ b/src/tabs/debug.ts
@@ -44,7 +44,8 @@ export default function showDebug(
         .replace(/-/g, ' ')
         .replace(/\b\w/g, (c) => c.toUpperCase())
       const assetUrl = (assetUrls as Record<string, string>)[path]
-      const baseUrl = assetUrl.substring(0, assetUrl.lastIndexOf('/') + 1)
+      const absUrl = new URL(assetUrl, import.meta.url).href
+      const baseUrl = absUrl.substring(0, absUrl.lastIndexOf('/') + 1)
       const spec: any = JSON.parse(JSON.stringify((mod as any).default))
       for (const part of spec.parts) {
         if (part.mesh) {
@@ -62,7 +63,7 @@ export default function showDebug(
           }
         }
       }
-      return { name, spec }
+      return { name, spec, baseUrl }
     })
     .sort((a, b) => a.name.localeCompare(b.name))
   characters.forEach((c) => {
@@ -87,7 +88,7 @@ export default function showDebug(
     const ch = characters.find((c) => c.name === name)
     if (!ch) return
     const loader = new BlockyCharacterLoader()
-    const obj = await loader.fromSpec(ch.spec)
+    const obj = await loader.fromSpec(ch.spec, ch.baseUrl)
     if (model) scene.remove(model)
     model = obj
     scene.add(model)


### PR DESCRIPTION
## Summary
- update BlockyCharacterLoader to accept explicit `baseUrl` when loading a spec
- character debug screen loads specs directly via `import.meta.glob` and passes them to the loader

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687e5b14854c8333a12351d8cd301e7d