### PR TITLE
Adjust skeleton warrior height

### DIFF
--- a/src/assets/characters/skeleton-warrior-blocky.json
+++ b/src/assets/characters/skeleton-warrior-blocky.json
@@ -1,40 +1,40 @@
 {
-  "voxelHeight": 3,
+  "voxelHeight": 2,
   "parts": [
     {
       "name": "head",
-      "size": [0.6, 0.6, 0.6],
-      "position": [0, 1.8, 0],
+      "size": [0.6, 0.41, 0.6],
+      "position": [0, 1.79, 0],
       "color": "#eeeeee"
     },
     {
       "name": "body",
-      "size": [0.8, 1.0, 0.4],
-      "position": [0, 0.9, 0],
+      "size": [0.8, 0.69, 0.4],
+      "position": [0, 1.17, 0],
       "color": "#dddddd"
     },
     {
       "name": "leftArm",
-      "size": [0.2, 1.0, 0.2],
-      "position": [-0.55, 0.9, 0],
+      "size": [0.2, 0.69, 0.2],
+      "position": [-0.55, 1.17, 0],
       "color": "#eeeeee"
     },
     {
       "name": "rightArm",
-      "size": [0.2, 1.0, 0.2],
-      "position": [0.55, 0.9, 0],
+      "size": [0.2, 0.69, 0.2],
+      "position": [0.55, 1.17, 0],
       "color": "#eeeeee"
     },
     {
       "name": "leftLeg",
-      "size": [0.2, 1.2, 0.2],
-      "position": [-0.25, -0.2, 0],
+      "size": [0.2, 0.83, 0.2],
+      "position": [-0.25, 0.41, 0],
       "color": "#dddddd"
     },
     {
       "name": "rightLeg",
-      "size": [0.2, 1.2, 0.2],
-      "position": [0.25, -0.2, 0],
+      "size": [0.2, 0.83, 0.2],
+      "position": [0.25, 0.41, 0],
       "color": "#dddddd"
     }
   ]


### PR DESCRIPTION
## Summary
- tweak skeleton warrior voxel height so it only occupies two vertical cells
- resize and reposition skeleton parts to visually match a 2-voxel tall model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e6b5a85b8833395929b2f328d8bc2