### PR TITLE
Add skeleton spawn to forest map

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ following biomes are defined:
 - **forest** – default biome using a multi‑octave Perlin terrain generator. The
   landscape features steep hills and occasional caves filled with swamp and tree
   voxels. Apples, stumps and piles of fallen leaves appear scattered around the
-  woods. No ceiling is placed and a distant dark sky texture surrounds the map.
+  woods. A handful of skeleton warriors are placed randomly when the map is
+  generated. No ceiling is placed and a distant dark sky texture surrounds the
+  map.
 - **cave** – darker environment with damp weather.
 - **plain** – open terrain with windy weather.
 

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -174,6 +174,7 @@ export default class DungeonView3D {
     this.torch.add(light)
     this.scene.add(this.torch)
     this.spawnEnvironment()
+    this.spawnMapEnemies()
   }
 
   private handleKeyDown = (e: KeyboardEvent) => {
@@ -824,6 +825,28 @@ export default class DungeonView3D {
       loader.load().then((base) => {
         this.enemyBase = base
         this.addEnemies()
+      })
+    }
+  }
+
+  private spawnMapEnemies() {
+    const map: any = this.map as any
+    if (!map.enemies || map.enemies.length === 0) return
+    const add = () => {
+      map.enemies.forEach((e: any) => {
+        this.enemies.push({ enemy: e.template, x: e.x, y: e.y })
+      })
+      this.addEnemies()
+    }
+    if (this.enemyBase) {
+      add()
+    } else {
+      const loader = new BlockyCharacterLoader(
+        new URL('../../assets/characters/skeleton-warrior-blocky.json', import.meta.url).href
+      )
+      loader.load().then((base) => {
+        this.enemyBase = base
+        add()
       })
     }
   }

--- a/src/games/world/ForestMap.ts
+++ b/src/games/world/ForestMap.ts
@@ -1,5 +1,5 @@
 import type { Direction } from '../dungeon-rpg/Player'
-import { MapEnemy } from '../dungeon-rpg/Enemy'
+import { MapEnemy, skeletonWarrior } from '../dungeon-rpg/Enemy'
 import VoxelMap from './VoxelMap'
 import { VoxelType } from './voxels'
 import { createTreeObject } from './VoxelObject'
@@ -24,6 +24,7 @@ export default class ForestMap extends VoxelMap {
     this.generate()
     this.buildVoxels()
     this.placeEnvironmentItems()
+    this.placeEnemies()
   }
 
   get playerStart() {
@@ -53,7 +54,21 @@ export default class ForestMap extends VoxelMap {
   }
 
   private placeEnemies() {
-    // intentionally left blank – enemies will spawn dynamically elsewhere
+    const count = Math.floor(this.width * this.height * 0.001)
+    for (let i = 0; i < count; i++) {
+      let placed = false
+      for (let t = 0; t < 50 && !placed; t++) {
+        const x = this.rand(1, this.width - 1)
+        const y = this.rand(1, this.height - 1)
+        if (this.tileAt(x, y) === '.') {
+          const baseH = this.getHeight(x, y)
+          if (this.isClearAbove(x, y, baseH + 1, 2)) {
+            this.enemies.push(new MapEnemy(skeletonWarrior, x, y))
+            placed = true
+          }
+        }
+      }
+    }
   }
 
   private placeEnvironmentItems() {


### PR DESCRIPTION
## Summary
- spawn skeleton warriors when generating ForestMap
- render map enemies in the 3D view
- mention enemies in forest biome description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6b788e808333a4ece952b7116245