### PR TITLE
Add biome-aware ambient music system

### DIFF
--- a/src/audio/BasicSynth.ts
+++ b/src/audio/BasicSynth.ts
@@ -2,14 +2,20 @@ export interface BasicSynthOptions {
   type?: OscillatorType
   gain?: number
   context?: any
+  destination?: AudioNode
+  eqFilters?: { type?: BiquadFilterType; frequency: number; q?: number; gain?: number }[]
+  reverbDuration?: number
 }
 
 export default class BasicSynth {
   private context: any
   private master: GainNode
+  private destination: AudioNode
   private oscillator: OscillatorNode | null = null
   private type: OscillatorType
   private gain: number
+  private filters: BiquadFilterNode[] = []
+  private convolver?: ConvolverNode
 
   constructor(options: BasicSynthOptions = {}) {
     if (options.context) {
@@ -20,7 +26,38 @@ export default class BasicSynth {
       throw new Error('No AudioContext available')
     }
     this.master = this.context.createGain()
-    this.master.connect(this.context.destination)
+    this.destination = options.destination ?? this.context.destination
+    let last: AudioNode = this.master
+    if (options.eqFilters) {
+      this.filters = options.eqFilters.map((f) => {
+        const node = this.context.createBiquadFilter()
+        if (f.type) node.type = f.type
+        node.frequency.value = f.frequency
+        if (f.q) node.Q.value = f.q
+        if (typeof f.gain === 'number') node.gain.value = f.gain
+        last.connect(node)
+        last = node
+        return node
+      })
+    }
+
+    if (options.reverbDuration) {
+      const len = this.context.sampleRate * options.reverbDuration
+      const impulse = this.context.createBuffer(2, len, this.context.sampleRate)
+      for (let c = 0; c < 2; c++) {
+        const ch = impulse.getChannelData(c)
+        for (let i = 0; i < len; i++) {
+          ch[i] = (Math.random() * 2 - 1) * (1 - i / len)
+        }
+      }
+      const conv = this.context.createConvolver()
+      conv.buffer = impulse
+      last.connect(conv)
+      last = conv
+      this.convolver = conv
+    }
+
+    last.connect(this.destination)
     this.type = options.type ?? 'sine'
     this.gain = options.gain ?? 0.2
   }
@@ -60,5 +97,22 @@ export default class BasicSynth {
     if (this.oscillator) {
       this.oscillator.stop()
     }
+  }
+
+  connect(node: AudioNode) {
+    this.master.disconnect()
+    this.destination = node
+    let last: AudioNode = this.master
+    if (this.filters.length) {
+      for (const f of this.filters) {
+        last.connect(f)
+        last = f
+      }
+    }
+    if (this.convolver) {
+      last.connect(this.convolver)
+      last = this.convolver
+    }
+    last.connect(node)
   }
 }

--- a/src/audio/BiomeMusicManager.ts
+++ b/src/audio/BiomeMusicManager.ts
@@ -1,0 +1,54 @@
+import MasterOutput from './MasterOutput'
+import BasicSynth from './BasicSynth'
+import MusicGenerator from './MusicGenerator'
+import Piano from './instruments/Piano'
+import Pad from './instruments/Pad'
+import { Biome } from '../games/world/biomes'
+
+export default class BiomeMusicManager {
+  private master: MasterOutput
+  private pad?: Pad
+  private piano?: Piano
+  private generator?: MusicGenerator
+  private current?: Biome
+
+  constructor(master?: MasterOutput) {
+    this.master = master ?? new MasterOutput()
+  }
+
+  setBiome(biome: Biome) {
+    this.current = biome
+    const music = biome.music
+    const padSynth = new BasicSynth({
+      context: this.master.context,
+      destination: this.master.input,
+      eqFilters: [
+        { type: 'highpass', frequency: 80 },
+        { type: 'lowpass', frequency: 12000 },
+      ],
+      reverbDuration: music?.reverb ? 2 : undefined,
+    })
+    const pianoSynth = new BasicSynth({
+      context: this.master.context,
+      destination: this.master.input,
+      eqFilters: [
+        { type: 'highpass', frequency: 120 },
+        { type: 'lowpass', frequency: 8000 },
+      ],
+      reverbDuration: music?.reverb ? 2 : undefined,
+    })
+    this.pad = new Pad(padSynth)
+    this.piano = new Piano(pianoSynth)
+    this.generator = new MusicGenerator(this.pad)
+  }
+
+  start() {
+    if (!this.current || !this.generator || !this.pad || !this.piano) return
+    const tracks = MusicGenerator.generateFixedTracks([this.pad, this.piano])
+    this.master.master.gain.cancelScheduledValues(this.master.context.currentTime)
+    const g = this.master.master.gain
+    g.setValueAtTime(0, this.master.context.currentTime)
+    g.linearRampToValueAtTime(0.05, this.master.context.currentTime + 15)
+    MusicGenerator.playTracks(tracks)
+  }
+}

--- a/src/audio/MasterOutput.ts
+++ b/src/audio/MasterOutput.ts
@@ -1,0 +1,24 @@
+export default class MasterOutput {
+  public context: AudioContext
+  public master: GainNode
+  public compressor: DynamicsCompressorNode
+
+  constructor(context?: AudioContext) {
+    if (context) {
+      this.context = context
+    } else if (typeof AudioContext !== 'undefined') {
+      this.context = new AudioContext()
+    } else {
+      throw new Error('No AudioContext available')
+    }
+    this.compressor = this.context.createDynamicsCompressor()
+    this.master = this.context.createGain()
+    this.master.gain.value = 0.05
+    this.master.connect(this.compressor)
+    this.compressor.connect(this.context.destination)
+  }
+
+  get input(): AudioNode {
+    return this.master
+  }
+}

--- a/src/audio/biomeSettings.ts
+++ b/src/audio/biomeSettings.ts
@@ -1,0 +1,19 @@
+export interface MusicSettings {
+  tempo: number
+  reverb: boolean
+}
+
+export const forestMusic: MusicSettings = {
+  tempo: 60,
+  reverb: true,
+}
+
+export const caveMusic: MusicSettings = {
+  tempo: 90,
+  reverb: false,
+}
+
+export const plainMusic: MusicSettings = {
+  tempo: 100,
+  reverb: false,
+}

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import DungeonMap from '../dungeon-rpg/DungeonMap'
 import { Biome, forestBiome } from '../world/biomes'
+import BiomeMusicManager from '../../audio/BiomeMusicManager'
 import { VoxelType } from '../world/voxels'
 import Player, { Direction } from '../dungeon-rpg/Player'
 import Hero from '../dungeon-rpg/Hero'
@@ -23,6 +24,7 @@ export default class DungeonView3D {
   private renderer: THREE.WebGLRenderer
   private map: DungeonMap
   private biome: Biome
+  private music: BiomeMusicManager
   private player: Player
   private hero: Hero
   private enemies: { enemy: Enemy; x: number; y: number; mesh?: THREE.Object3D }[] = []
@@ -71,6 +73,9 @@ export default class DungeonView3D {
     biome: Biome = forestBiome
   ) {
     this.biome = biome
+    this.music = new BiomeMusicManager()
+    this.music.setBiome(biome)
+    this.music.start()
     this.map = biome.generateMap() as DungeonMap
     this.player = new Player(this.map.playerStart)
     this.hero = new Hero()
@@ -858,5 +863,11 @@ export default class DungeonView3D {
       }
     }
     this.spawnEnvironmentMesh(template, x, y)
+  }
+
+  setBiome(biome: Biome) {
+    this.biome = biome
+    this.music.setBiome(biome)
+    this.music.start()
   }
 }

--- a/src/games/dungeon-rpg-three/initGame.ts
+++ b/src/games/dungeon-rpg-three/initGame.ts
@@ -1,5 +1,5 @@
 import DungeonView3D from './DungeonView3D'
-import { forestBiome } from '../world/biomes'
+import { forestBiome, biomes } from '../world/biomes'
 
 export default function initThreeGame(
   container: HTMLElement,
@@ -42,6 +42,12 @@ export default function initThreeGame(
           <div style="font-weight:bold;margin-bottom:4px;">Spawn</div>
           <select id="spawn-select" style="width:100%;margin-bottom:4px;"></select>
           <button id="spawn-btn">Spawn</button>
+          <div style="margin-top:10px;font-weight:bold;">Biome</div>
+          <select id="biome-select" style="width:100%;margin-bottom:4px;">
+            <option value="forest">forest</option>
+            <option value="cave">cave</option>
+            <option value="plain">plain</option>
+          </select>
         </div>
         </div>
       </div>
@@ -60,6 +66,7 @@ export default function initThreeGame(
   const charList = container.querySelector('#character-list') as HTMLPreElement
   const spawnSelect = container.querySelector('#spawn-select') as HTMLSelectElement
   const spawnBtn = container.querySelector('#spawn-btn') as HTMLButtonElement
+  const biomeSelect = container.querySelector('#biome-select') as HTMLSelectElement
   const heroControls = container.querySelector('#hero-controls') as HTMLDivElement
   const heroHp = heroControls.querySelector('#hero-hp') as HTMLInputElement
   const heroHunger = heroControls.querySelector('#hero-hunger') as HTMLInputElement
@@ -81,6 +88,11 @@ export default function initThreeGame(
 
   spawnBtn.addEventListener('click', () => {
     view.spawnCharacter(spawnSelect.value)
+  })
+
+  biomeSelect.addEventListener('change', () => {
+    const val = biomeSelect.value as 'forest' | 'cave' | 'plain'
+    view.setBiome(biomes[val])
   })
 
   function updateHero() {

--- a/src/games/world/biomes.ts
+++ b/src/games/world/biomes.ts
@@ -3,6 +3,7 @@ import { VoxelType } from './voxels'
 import VoxelMap from './VoxelMap'
 import DungeonMap from '../dungeon-rpg/DungeonMap'
 import ForestMap from './ForestMap'
+import { MusicSettings, forestMusic, caveMusic, plainMusic } from '../../audio/biomeSettings'
 import {
   swampTexture,
   treeTexture,
@@ -37,6 +38,7 @@ export interface Biome {
   floorTexture?: () => THREE.Texture
   treeTexture?: () => THREE.Texture
   leavesTexture?: () => THREE.Texture
+  music?: MusicSettings
 }
 
 export const forestBiome: Biome = {
@@ -53,6 +55,7 @@ export const forestBiome: Biome = {
   floorTexture: swampTexture,
   treeTexture: () => treeTexture(40),
   leavesTexture: () => createLeavesTexture(20),
+  music: forestMusic,
 }
 
 export const caveBiome: Biome = {
@@ -63,6 +66,7 @@ export const caveBiome: Biome = {
   fog: '#555555',
   weather: 'damp',
   lighting: { color: 0x888888, intensity: 0.5 },
+  music: caveMusic,
 }
 
 export const plainBiome: Biome = {
@@ -73,6 +77,7 @@ export const plainBiome: Biome = {
   fog: '#ccffcc',
   weather: 'windy',
   lighting: { color: 0xffffff, intensity: 1 },
+  music: plainMusic,
 }
 
 export const biomes = {

--- a/tests/BasicSynth.test.ts
+++ b/tests/BasicSynth.test.ts
@@ -22,6 +22,8 @@ class MockContext {
   destination = {}
   createOscillator() { return new MockOscillator() }
   createGain() { return new MockGain() }
+  createBiquadFilter() { return { connect() {}, frequency: { value: 0 }, Q: { value: 0 }, gain: { value: 0 } } as any }
+  createConvolver() { return { connect() {}, buffer: null } as any }
 }
 
 async function run() {


### PR DESCRIPTION
## Summary
- introduce `MusicSettings` for biome-specific music configuration
- implement `MasterOutput` with compressor and 5% master gain
- extend `BasicSynth` to support EQ filters and reverb
- create `BiomeMusicManager` that fades music in over 15 seconds
- connect music system to biomes and allow runtime biome changes
- add biome selection UI in the three.js game
- adjust tests for updated audio classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6d1a25688333a7a2a1d53dd29ad0