### PR TITLE
Add biome-aware music presets

### DIFF
--- a/src/audio/biomeMusic.ts
+++ b/src/audio/biomeMusic.ts
@@ -1,0 +1,18 @@
+export interface MusicSettings {
+  instruments: (() => import('./instruments/Instrument').default)[]
+}
+
+import Piano from './instruments/Piano'
+import Pad from './instruments/Pad'
+
+export const forestMusic: MusicSettings = {
+  instruments: [() => new Pad(), () => new Piano()],
+}
+
+export const caveMusic: MusicSettings = {
+  instruments: [() => new Pad()],
+}
+
+export const plainMusic: MusicSettings = {
+  instruments: [() => new Piano()],
+}

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import DungeonMap from '../dungeon-rpg/DungeonMap'
 import { Biome, forestBiome } from '../world/biomes'
+import MusicGenerator from '../../audio/MusicGenerator'
 import { VoxelType } from '../world/voxels'
 import Player, { Direction } from '../dungeon-rpg/Player'
 import Hero from '../dungeon-rpg/Hero'
@@ -57,6 +58,7 @@ export default class DungeonView3D {
   private mapCenterX = 0
   private mapCenterY = 0
   private enemyBase?: THREE.Group
+  private musicGenerator?: MusicGenerator
   private items: { name: string; x: number; y: number; mesh: THREE.Object3D }[] = []
   private floatMode = false
   private floatOffset = 0
@@ -140,6 +142,7 @@ export default class DungeonView3D {
     this.startRot = this.camera.rotation.y
     this.targetPos.copy(this.startPos)
     this.targetRot = this.startRot
+    this.initMusic(this.biome)
   }
 
 
@@ -881,5 +884,19 @@ export default class DungeonView3D {
       }
     }
     this.spawnEnvironmentMesh(template, x, y)
+  }
+
+  private initMusic(biome: Biome) {
+    if (!biome.music) return
+    const instruments = biome.music.instruments.map((fn) => fn())
+    if (instruments.length === 0) return
+    this.musicGenerator = new MusicGenerator(instruments[0])
+    const tracks = MusicGenerator.generateFixedTracks(instruments)
+    MusicGenerator.playTracks(tracks)
+  }
+
+  setBiome(biome: Biome) {
+    this.biome = biome
+    this.initMusic(biome)
   }
 }

--- a/src/games/world/biomes.ts
+++ b/src/games/world/biomes.ts
@@ -22,6 +22,9 @@ import EnvironmentCharacter, {
   stump,
   fallenLeaves,
 } from '../dungeon-rpg/Environment'
+import { caveMusic, forestMusic, plainMusic } from '../../audio/biomeMusic'
+
+import { MusicSettings } from '../../audio/biomeMusic'
 
 export interface Biome {
   name: string
@@ -37,6 +40,7 @@ export interface Biome {
   floorTexture?: () => THREE.Texture
   treeTexture?: () => THREE.Texture
   leavesTexture?: () => THREE.Texture
+  music?: MusicSettings
 }
 
 export const forestBiome: Biome = {
@@ -53,6 +57,7 @@ export const forestBiome: Biome = {
   floorTexture: swampTexture,
   treeTexture: () => treeTexture(40),
   leavesTexture: () => createLeavesTexture(20),
+  music: forestMusic,
 }
 
 export const caveBiome: Biome = {
@@ -63,6 +68,7 @@ export const caveBiome: Biome = {
   fog: '#555555',
   weather: 'damp',
   lighting: { color: 0x888888, intensity: 0.5 },
+  music: caveMusic,
 }
 
 export const plainBiome: Biome = {
@@ -73,6 +79,7 @@ export const plainBiome: Biome = {
   fog: '#ccffcc',
   weather: 'windy',
   lighting: { color: 0xffffff, intensity: 1 },
+  music: plainMusic,
 }
 
 export const biomes = {


### PR DESCRIPTION
## Summary
- add `MusicSettings` with simple instrument presets
- expand `Biome` definitions to include a `music` option
- initialize `MusicGenerator` in `DungeonView3D` according to the biome
- provide a `setBiome` method for switching music presets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e70d0673883338349e216c3519fad