### PR TITLE
Add ambient music generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This project is a small website built with Vite. It contains a 3D dungeon game i
 The game now supports **biomes** which control map generation and environmental
 features. Currently available biomes are **forest**, **cave**, and **plain**.
 
+Ambient background music is generated automatically using a small
+synthesizer. See `docs/ambient-music.md` for an overview of the system.
+
 ## Development
 
 Install dependencies and start the development server:

--- a/docs/ambient-music.md
+++ b/docs/ambient-music.md
@@ -1,0 +1,10 @@
+# Ambient Music Generation
+
+このプロジェクトではゲーム内の環境に合わせてアンビエントなBGMを自動生成するシステムを導入しています。
+
+## 概要
+- `AmbientPad` クラスを使い、ゆったりとしたパッド音を鳴らします。
+- `MusicGenerator.generateAmbientTracks` で長い音価を中心としたシーケンスを生成します。
+- `biomeMusic.ts` では各バイオームのデフォルト楽器として `AmbientPad` を利用します。
+
+詳細はコードを参照してください。

--- a/src/audio/BasicSynth.ts
+++ b/src/audio/BasicSynth.ts
@@ -24,6 +24,7 @@ export default class BasicSynth {
       throw new Error('No AudioContext available')
     }
     this.master = this.context.createGain()
+    this.master.gain.value = 1
     this.master.connect(this.context.destination)
 
     if (options.filterFrequency !== undefined) {
@@ -63,7 +64,16 @@ export default class BasicSynth {
     this.delay!.delayTime.value = time
   }
 
-  play(frequency: number, duration = 1) {
+  getCurrentTime() {
+    return this.context.currentTime
+  }
+
+  fadeIn(duration = 2) {
+    this.master.gain.setValueAtTime(0, this.context.currentTime)
+    this.master.gain.linearRampToValueAtTime(1, this.context.currentTime + duration)
+  }
+
+  play(frequency: number, duration = 1, startTime?: number) {
     if (this.oscillator) {
       this.stop()
     }
@@ -83,8 +93,9 @@ export default class BasicSynth {
       node = this.delay
     }
     node.connect(this.master)
-    osc.start()
-    osc.stop(this.context.currentTime + duration)
+    const start = startTime ?? this.context.currentTime
+    osc.start(start)
+    osc.stop(start + duration)
     osc.onended = () => {
       osc.disconnect()
       gain.disconnect()

--- a/src/audio/MusicGenerator.ts
+++ b/src/audio/MusicGenerator.ts
@@ -72,6 +72,24 @@ export default class MusicGenerator {
     return tracks
   }
 
+  static generateAmbientTracks(
+    instruments: Instrument[],
+    bars = 4,
+    scale: number[] = [261.63, 293.66, 329.63, 392.0]
+  ): Track[] {
+    const tracks: Track[] = []
+    const steps = bars
+    for (const instrument of instruments) {
+      const seq: NoteEvent[] = []
+      for (let i = 0; i < steps; i++) {
+        const freq = scale[Math.floor(Math.random() * scale.length)]
+        seq.push({ frequency: freq, duration: 2 })
+      }
+      tracks.push({ instrument, sequence: seq })
+    }
+    return tracks
+  }
+
   static playTracks(tracks: Track[]) {
     for (const track of tracks) {
       for (const note of track.sequence) {

--- a/src/audio/MusicGenerator.ts
+++ b/src/audio/MusicGenerator.ts
@@ -17,9 +17,15 @@ export default class MusicGenerator {
     this.instrument = instrument
   }
 
-  playSequence(sequence: NoteEvent[]) {
+  playSequence(sequence: NoteEvent[], fadeIn = false) {
+    const base = this.instrument.getCurrentTime()
+    let t = base
+    if (fadeIn) {
+      this.instrument.fadeIn(2)
+    }
     for (const note of sequence) {
-      this.instrument.play(note.frequency, note.duration)
+      this.instrument.play(note.frequency, note.duration, t)
+      t += note.duration
     }
   }
 
@@ -90,10 +96,16 @@ export default class MusicGenerator {
     return tracks
   }
 
-  static playTracks(tracks: Track[]) {
+  static playTracks(tracks: Track[], fadeIn = false) {
+    const base = tracks[0]?.instrument.getCurrentTime() ?? 0
     for (const track of tracks) {
+      let t = base
+      if (fadeIn) {
+        track.instrument.fadeIn(2)
+      }
       for (const note of track.sequence) {
-        track.instrument.play(note.frequency, note.duration)
+        track.instrument.play(note.frequency, note.duration, t)
+        t += note.duration
       }
     }
   }

--- a/src/audio/biomeMusic.ts
+++ b/src/audio/biomeMusic.ts
@@ -3,20 +3,20 @@ export interface MusicSettings {
 }
 
 import Piano from './instruments/Piano'
-import Pad from './instruments/Pad'
+import AmbientPad from './instruments/AmbientPad'
 
 export const forestMusic: MusicSettings = {
-  instruments: [() => new Pad(), () => new Piano()],
+  instruments: [() => new AmbientPad(), () => new Piano()],
 }
 
 export const caveMusic: MusicSettings = {
-  instruments: [() => new Pad()],
+  instruments: [() => new AmbientPad()],
 }
 
 export const plainMusic: MusicSettings = {
-  instruments: [() => new Piano()],
+  instruments: [() => new AmbientPad()],
 }
 
 export const desertMusic: MusicSettings = {
-  instruments: [() => new Pad(), () => new Piano()],
+  instruments: [() => new AmbientPad(), () => new Piano()],
 }

--- a/src/audio/instruments/AmbientPad.ts
+++ b/src/audio/instruments/AmbientPad.ts
@@ -1,0 +1,15 @@
+import BasicSynth from '../BasicSynth'
+import Instrument, { InstrumentPreset } from './Instrument'
+import { ambientPadPreset } from './presets'
+
+export default class AmbientPad extends Instrument {
+  constructor(synth?: BasicSynth, preset: InstrumentPreset = ambientPadPreset) {
+    const s =
+      synth ??
+      new BasicSynth({
+        filterFrequency: 700,
+        delayTime: 0.4,
+      })
+    super(s, preset)
+  }
+}

--- a/src/audio/instruments/Instrument.ts
+++ b/src/audio/instruments/Instrument.ts
@@ -12,7 +12,7 @@ export default class Instrument {
     this.preset = preset
   }
 
-  play(frequency: number, duration = 1) {
+  play(frequency: number, duration = 1, startTime?: number) {
     if (typeof this.synth.setType === 'function') {
       this.synth.setType(this.preset.type)
     } else {
@@ -23,6 +23,19 @@ export default class Instrument {
     } else {
       ;(this.synth as any).gain = this.preset.gain
     }
-    this.synth.play(frequency, duration)
+    this.synth.play(frequency, duration, startTime)
+  }
+
+  getCurrentTime(): number {
+    if (typeof this.synth.getCurrentTime === 'function') {
+      return this.synth.getCurrentTime()
+    }
+    return 0
+  }
+
+  fadeIn(duration = 2) {
+    if (typeof this.synth.fadeIn === 'function') {
+      this.synth.fadeIn(duration)
+    }
   }
 }

--- a/src/audio/instruments/presets.ts
+++ b/src/audio/instruments/presets.ts
@@ -7,3 +7,8 @@ export const padPreset = {
   type: 'sine' as OscillatorType,
   gain: 0.2,
 }
+
+export const ambientPadPreset = {
+  type: 'sine' as OscillatorType,
+  gain: 0.15,
+}

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -1033,8 +1033,8 @@ export default class DungeonView3D {
     const instruments = biome.music.instruments.map((fn) => fn())
     if (instruments.length === 0) return
     this.musicGenerator = new MusicGenerator(instruments[0])
-    const tracks = MusicGenerator.generateFixedTracks(instruments)
-    MusicGenerator.playTracks(tracks)
+    const tracks = MusicGenerator.generateAmbientTracks(instruments)
+    MusicGenerator.playTracks(tracks, true)
   }
 
   setBiome(biome: Biome) {

--- a/tests/MusicGenerator.test.ts
+++ b/tests/MusicGenerator.test.ts
@@ -2,6 +2,7 @@ import assert from 'assert'
 import MusicGenerator from '../src/audio/MusicGenerator'
 import Piano from '../src/audio/instruments/Piano'
 import Pad from '../src/audio/instruments/Pad'
+import AmbientPad from '../src/audio/instruments/AmbientPad'
 
 class MockSynth {
   public type: OscillatorType = 'sine'
@@ -44,6 +45,13 @@ async function run() {
   const tracksRandom = MusicGenerator.generateRandomTracks([piano2, pad2], 1, [440, 660])
   assert.strictEqual(tracksRandom.length, 2)
   assert.strictEqual(tracksRandom[0].sequence.length, 4)
+
+  const ambientSynth = new MockSynth()
+  const ambientPad = new AmbientPad(ambientSynth as any)
+  const ambientTracks = MusicGenerator.generateAmbientTracks([ambientPad], 1, [220])
+  assert.strictEqual(ambientTracks[0].sequence[0].duration, 2)
+  MusicGenerator.playTracks(ambientTracks)
+  assert.ok(ambientSynth.played.length > 0)
 
   console.log('MusicGenerator test passed')
 }

--- a/tests/MusicGenerator.test.ts
+++ b/tests/MusicGenerator.test.ts
@@ -7,11 +7,11 @@ import AmbientPad from '../src/audio/instruments/AmbientPad'
 class MockSynth {
   public type: OscillatorType = 'sine'
   public gain = 0.2
-  public played: {frequency: number; duration: number}[] = []
+  public played: {frequency: number; duration: number; start?: number}[] = []
   setType(type: OscillatorType) { this.type = type }
   setGain(gain: number) { this.gain = gain }
-  play(frequency: number, duration: number) {
-    this.played.push({ frequency, duration })
+  play(frequency: number, duration: number, start?: number) {
+    this.played.push({ frequency, duration, start })
   }
 }
 
@@ -24,6 +24,8 @@ async function run() {
     { frequency: 660, duration: 0.5 },
   ])
   assert.strictEqual(synth.played.length, 2, 'should play two notes')
+  assert.strictEqual(synth.played[0].start, 0)
+  assert.strictEqual(synth.played[1].start, 1)
   assert.strictEqual(synth.type, 'triangle')
   const padSynth = new MockSynth()
   const pad = new Pad(padSynth as any)
@@ -41,6 +43,8 @@ async function run() {
   MusicGenerator.playTracks(tracks)
   assert.ok(padSynth2.played.length > 0, 'pad track should play notes')
   assert.ok(pianoSynth2.played.length > 0, 'piano track should play notes')
+  assert.strictEqual(padSynth2.played[0].start, 0)
+  assert.strictEqual(padSynth2.played[1].start, 1)
 
   const tracksRandom = MusicGenerator.generateRandomTracks([piano2, pad2], 1, [440, 660])
   assert.strictEqual(tracksRandom.length, 2)


### PR DESCRIPTION
## Summary
- introduce AmbientPad instrument and preset
- generate ambient tracks for long sustained notes
- use AmbientPad in all biome music settings
- document ambient music system
- update tests for new ambient features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f563ee78c83339ed7a15ef4045033