### PR TITLE
Add skeleton system for characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,7 @@ Additional systems like weather effects are planned but not yet implemented.
 
 - [Character Animation Design](docs/character-animation.md)
 - [Player Arm Animation Guide](docs/arm-animation.md)
+- The character loader now creates a simple bone hierarchy using the new
+  [Skeleton](src/games/animation/Skeleton.ts) class. Animations operate on these
+  bones.
 

--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ Additional systems like weather effects are planned but not yet implemented.
 - [Player Arm Animation Guide](docs/arm-animation.md)
 - The character loader now creates a simple bone hierarchy using the new
   [Skeleton](src/games/animation/Skeleton.ts) class. Animations operate on these
-  bones.
+  bones. The loader attaches the skeleton and a map of body parts directly on
+  the returned `THREE.Group` so cloned meshes do not serialize them.
 

--- a/docs/character-animation.md
+++ b/docs/character-animation.md
@@ -22,7 +22,9 @@ It manages a collection of named bones implemented as `THREE.Object3D` nodes.
 Bones can be added dynamically and queried through `getJoints()` which returns
 a record of bone objects keyed by name. `BlockyCharacterLoader` now builds
 characters using this skeleton so that animations can operate on the bones
-directly.
+directly. The resulting `THREE.Group` returned by the loader exposes the
+`skeleton` and a `parts` map on the group itself (not in `userData`) so that
+cloning meshes does not attempt to serialize these structures.
 
 ## Vertex JSON / SVG Animation
 

--- a/docs/character-animation.md
+++ b/docs/character-animation.md
@@ -15,6 +15,15 @@ Characters are built from the following joints and parts. Each part is represent
 
 Additional joints can be defined as needed. Parts are connected in a hierarchy to mimic a simple skeleton.
 
+## Skeleton Class
+
+Version 2 introduces a small `Skeleton` helper (see `src/games/animation/Skeleton.ts`).
+It manages a collection of named bones implemented as `THREE.Object3D` nodes.
+Bones can be added dynamically and queried through `getJoints()` which returns
+a record of bone objects keyed by name. `BlockyCharacterLoader` now builds
+characters using this skeleton so that animations can operate on the bones
+directly.
+
 ## Vertex JSON / SVG Animation
 
 Shapes for each part can be designed in SVG and converted to vertex JSON using the existing conversion script (`npm run convert-svgs`). The resulting JSON files contain vertex arrays that can be loaded into `THREE.BufferGeometry` objects. By keeping geometry for each part separate, the same animation data can be reused with different meshes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "dungeon-survival-rpg",
       "version": "1.0.0",
       "devDependencies": {
+        "@types/three": "^0.178.1",
         "svg-path-properties": "^1.3.0",
         "svgson": "^5.3.1",
         "three": "^0.178.0",
@@ -28,6 +29,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -756,6 +764,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -773,6 +788,43 @@
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.178.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.178.1.tgz",
+      "integrity": "sha512-WSabew1mgWgRx2RfLfKY+9h4wyg6U94JfLbZEGU245j/WY2kXqU0MUfghS+3AYMV5ET1VlILAgpy77cB6a3Itw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.22.tgz",
+      "integrity": "sha512-Vr6Stjv5jPRqH690f5I5GLjVk8GSsoQSYJ2FVd/3jJF7KaqfwPi3ehfBS96mlQ2kPCwZaX6U0rG2+NGHBKkA/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.64",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
+      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -884,6 +936,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -925,6 +984,13 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "scripts": {
     "build": "vite build",
     "preview": "vite preview --config vite.config.ts --port 4173",
-    "test": "ts-node tests/BasicSynth.test.ts && ts-node tests/MusicGenerator.test.ts"
+    "test": "ts-node tests/BasicSynth.test.ts && ts-node tests/MusicGenerator.test.ts && ts-node tests/Skeleton.test.ts"
   },
   "devDependencies": {
-    "three": "^0.178.0",
-    "vite": "^5.0.0",
-    "svgson": "^5.3.1",
+    "@types/three": "^0.178.1",
     "svg-path-properties": "^1.3.0",
+    "svgson": "^5.3.1",
+    "three": "^0.178.0",
+    "ts-node": "^10.9.2",
     "typescript": "^5.0.0",
-    "ts-node": "^10.9.2"
+    "vite": "^5.0.0"
   }
 }

--- a/src/games/animation/Skeleton.ts
+++ b/src/games/animation/Skeleton.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three'
+
+export class Bone {
+  name: string
+  object: THREE.Object3D
+  children: Bone[] = []
+  constructor(name: string, object?: THREE.Object3D) {
+    this.name = name
+    this.object = object || new THREE.Object3D()
+  }
+  addChild(b: Bone) {
+    this.children.push(b)
+    this.object.add(b.object)
+  }
+}
+
+export default class Skeleton {
+  root: Bone
+  private bones: Record<string, Bone> = {}
+
+  constructor(rootName = 'root') {
+    this.root = new Bone(rootName, new THREE.Group())
+    this.bones[rootName] = this.root
+  }
+
+  addBone(name: string, parentName = 'root'): Bone {
+    const parent = this.bones[parentName]
+    if (!parent) throw new Error(`parent bone ${parentName} not found`)
+    const bone = new Bone(name)
+    parent.addChild(bone)
+    this.bones[name] = bone
+    return bone
+  }
+
+  getBone(name: string): THREE.Object3D {
+    const b = this.bones[name]
+    if (!b) throw new Error(`bone ${name} not found`)
+    return b.object
+  }
+
+  getJoints(): Record<string, THREE.Object3D> {
+    const joints: Record<string, THREE.Object3D> = {}
+    for (const [name, bone] of Object.entries(this.bones)) {
+      joints[name] = bone.object
+    }
+    return joints
+  }
+}

--- a/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
+++ b/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
@@ -44,8 +44,9 @@ export default class BlockyCharacterLoader {
   async fromSpec(spec: CharacterSpec, baseUrl?: string): Promise<THREE.Group> {
     const skeleton = new Skeleton()
     const group = skeleton.root.object as THREE.Group
-    ;(group.userData.parts ||= {})
-    group.userData.skeleton = skeleton
+    const parts: Record<string, THREE.Object3D> = {}
+    Object.defineProperty(group, 'skeleton', { value: skeleton })
+    Object.defineProperty(group, 'parts', { value: parts })
     let urlBase = baseUrl || this.url.substring(0, this.url.lastIndexOf('/') + 1)
     if (!urlBase && typeof window !== 'undefined') {
       urlBase = window.location.origin + '/'
@@ -113,7 +114,7 @@ export default class BlockyCharacterLoader {
         bone.object.scale.set(...p.scale)
       }
       bone.object.add(mesh)
-      group.userData.parts[p.name] = bone.object
+      parts[p.name] = bone.object
     }
     return group
   }

--- a/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
+++ b/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import Skeleton from '../../animation/Skeleton'
 
 export type FaceDirection =
   | 'front'
@@ -11,6 +12,7 @@ export type FaceDirection =
 export interface PartSpec {
   name: string
   position: [number, number, number]
+  parent?: string
   size?: [number, number, number]
   mesh?: string
   scale?: [number, number, number]
@@ -40,8 +42,10 @@ export default class BlockyCharacterLoader {
   }
 
   async fromSpec(spec: CharacterSpec, baseUrl?: string): Promise<THREE.Group> {
-    const group = new THREE.Group()
+    const skeleton = new Skeleton()
+    const group = skeleton.root.object as THREE.Group
     ;(group.userData.parts ||= {})
+    group.userData.skeleton = skeleton
     let urlBase = baseUrl || this.url.substring(0, this.url.lastIndexOf('/') + 1)
     if (!urlBase && typeof window !== 'undefined') {
       urlBase = window.location.origin + '/'
@@ -103,12 +107,13 @@ export default class BlockyCharacterLoader {
         const mat = this.material || new THREE.MeshLambertMaterial({ color })
         mesh = new THREE.Mesh(geom, mat)
       }
-      mesh.position.set(...p.position)
+      const bone = skeleton.addBone(p.name, p.parent)
+      bone.object.position.set(...p.position)
       if (p.scale) {
-        mesh.scale.set(...p.scale)
+        bone.object.scale.set(...p.scale)
       }
-      group.add(mesh)
-      group.userData.parts[p.name] = mesh
+      bone.object.add(mesh)
+      group.userData.parts[p.name] = bone.object
     }
     return group
   }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -3,4 +3,10 @@ declare module '*.json' {
   export default value
 }
 
-declare module 'three'
+declare module 'three' {
+  interface Object3D {
+    parts?: Record<string, THREE.Object3D>
+    skeleton?: any
+  }
+}
+

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,3 +2,5 @@ declare module '*.json' {
   const value: any
   export default value
 }
+
+declare module 'three'

--- a/tests/Skeleton.test.ts
+++ b/tests/Skeleton.test.ts
@@ -1,0 +1,17 @@
+import assert from 'assert'
+import Skeleton from '../src/games/animation/Skeleton'
+
+async function run() {
+  const skel = new Skeleton()
+  const spine = skel.addBone('spine')
+  const head = skel.addBone('head', 'spine')
+  assert.ok(skel.getBone('head').parent === spine.object)
+  const joints = skel.getJoints()
+  assert.ok(joints.head === head.object)
+  console.log('Skeleton test passed')
+}
+
+run().catch(err => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- implement a simple `Skeleton` helper with named bones
- build character meshes using the skeleton in `BlockyCharacterLoader`
- document the new system in `README` and `docs/character-animation.md`
- include typings for `three` and add a unit test for the skeleton

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f56cbf0f08333ac447028446429f4