### PR TITLE
Add baseOffset for environment meshes

### DIFF
--- a/docs/character-animation.md
+++ b/docs/character-animation.md
@@ -44,13 +44,18 @@ This design makes it possible to create common animations (walking, attacking, j
 ## JSON Character Format
 
 Characters made from cubes can be described in external JSON files. Each file includes
-a `voxelHeight` property indicating how many vertical map cells the character occupies
-and an array of parts with a body part name, box size and offset.  Parts may also
-specify a display color or textures for individual faces:
+a `voxelHeight` property indicating how many vertical map cells the character occupies,
+an optional `baseOffset` specifying how far the model's origin is above its feet,
+and an array of parts with a body part name, box size and offset. Parts may also
+specify a display color or textures for individual faces.
+
+Environment models use this same format so decorative objects can also define a
+`baseOffset` if their origin does not sit directly on the ground:
 
 ```json
 {
   "voxelHeight": 3,
+  "baseOffset": 0.8,
   "parts": [
     {
       "name": "head",

--- a/src/assets/characters/blocky-doll.json
+++ b/src/assets/characters/blocky-doll.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 3,
+  "baseOffset": 0.7,
   "parts": [
     {
       "name": "head",

--- a/src/assets/characters/hero.json
+++ b/src/assets/characters/hero.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 3,
+  "baseOffset": 0.8,
   "parts": [
     {
       "name": "head",

--- a/src/assets/characters/quadruped-base.json
+++ b/src/assets/characters/quadruped-base.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 2,
+  "baseOffset": 0.4,
   "parts": [
     { "name": "body", "size": [1.0, 0.6, 2.0], "position": [0, 0.6, 0], "color": "#884400" },
     { "name": "head", "size": [0.5, 0.5, 0.5], "position": [0, 1.0, 0.9], "color": "#ccbbaa" },

--- a/src/assets/characters/skeleton-warrior-blocky.json
+++ b/src/assets/characters/skeleton-warrior-blocky.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 3.6,
+  "baseOffset": 0.0,
   "parts": [
     {
       "name": "head",

--- a/src/assets/characters/slime.json
+++ b/src/assets/characters/slime.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 1,
+  "baseOffset": 0.0,
   "parts": [
     { "name": "body", "size": [1.0, 0.8, 1.0], "position": [0, 0.4, 0], "color": "#66ff66" },
     { "name": "leftEye", "size": [0.1, 0.1, 0.1], "position": [-0.2, 0.6, 0.5], "color": "#000000" },

--- a/src/assets/environment/README.md
+++ b/src/assets/environment/README.md
@@ -3,6 +3,11 @@
 This directory stores JSON vertex data for decorative environment characters.
 The files are loaded directly by the game.
 
+Each mesh file uses the same JSON format as other characters. Besides
+`voxelHeight`, environment models may include an optional `baseOffset`
+indicating how far the origin is above the ground. This offset is applied
+when positioning the item in the world so the model rests on the ground.
+
 -Available character meshes:
 
 - `seaweed-blocky.json`

--- a/src/assets/environment/json/apple.json
+++ b/src/assets/environment/json/apple.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 1,
+  "baseOffset": 0,
   "parts": [
     {
       "name": "body",

--- a/src/assets/environment/json/bush.json
+++ b/src/assets/environment/json/bush.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 1,
+  "baseOffset": 0,
   "parts": [
     { "name": "body", "size": [1.2, 0.6, 1.2], "position": [0, 0.3, 0], "color": "#228833" }
   ]

--- a/src/assets/environment/json/fallenLeaves.json
+++ b/src/assets/environment/json/fallenLeaves.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 0.2,
+  "baseOffset": 0.025,
   "parts": [
     {
       "name": "pile",

--- a/src/assets/environment/json/grass.json
+++ b/src/assets/environment/json/grass.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 0.5,
+  "baseOffset": 0,
   "parts": [
     { "name": "clump", "size": [0.8, 0.4, 0.8], "position": [0, 0.2, 0], "color": "#33aa33" }
   ]

--- a/src/assets/environment/json/mushroom.json
+++ b/src/assets/environment/json/mushroom.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 1.5,
+  "baseOffset": 0,
   "parts": [
     { "name": "stem", "size": [0.3, 0.7, 0.3], "position": [0, 0.35, 0], "color": "#ffffff" },
     { "name": "cap", "size": [0.8, 0.3, 0.8], "position": [0, 0.95, 0], "color": "#ff3333" }

--- a/src/assets/environment/json/seaweed-blocky.json
+++ b/src/assets/environment/json/seaweed-blocky.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 2,
+  "baseOffset": 0,
   "parts": [
     {
       "name": "stem1",

--- a/src/assets/environment/json/stalactite.json
+++ b/src/assets/environment/json/stalactite.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 2,
+  "baseOffset": 0,
   "parts": [
     { "name": "spike", "size": [0.4, 1.8, 0.4], "position": [0, 0.9, 0], "color": "#999999" }
   ]

--- a/src/assets/environment/json/stone.json
+++ b/src/assets/environment/json/stone.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 0.6,
+  "baseOffset": 0,
   "parts": [
     { "name": "boulder", "size": [0.6, 0.6, 0.6], "position": [0, 0.3, 0], "color": "#777777" }
   ]

--- a/src/assets/environment/json/stump.json
+++ b/src/assets/environment/json/stump.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 1,
+  "baseOffset": 0,
   "parts": [
     {
       "name": "trunk",

--- a/src/assets/environment/json/tree.json
+++ b/src/assets/environment/json/tree.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 3,
+  "baseOffset": 0,
   "parts": [
     { "name": "trunk", "size": [0.5, 1.5, 0.5], "position": [0, 0.75, 0], "color": "#8b5a2b" },
     { "name": "crown", "size": [1.5, 1.5, 1.5], "position": [0, 2.25, 0], "color": "#228833" }

--- a/src/assets/environment/json/woodPiece.json
+++ b/src/assets/environment/json/woodPiece.json
@@ -1,5 +1,6 @@
 {
   "voxelHeight": 0.6,
+  "baseOffset": 0,
   "parts": [
     {
       "name": "log",

--- a/src/games/dungeon-rpg-three/DungeonView3D.ts
+++ b/src/games/dungeon-rpg-three/DungeonView3D.ts
@@ -337,9 +337,10 @@ export default class DungeonView3D {
         const scale = 0.3 * this.cellSize
         mesh.scale.set(scale, scale, scale)
         const h = (this.map.getHeight(e.x, e.y) + 1) * this.cellSize
+        const offset = (mesh.userData.baseOffset as number) || 0
         mesh.position.set(
           e.x * this.cellSize + this.cellSize / 2,
-          h,
+          h + offset * scale,
           e.y * this.cellSize + this.cellSize / 2
         )
         mesh.rotation.y = e.rot
@@ -424,9 +425,10 @@ export default class DungeonView3D {
       }
       if (e.mesh) {
         const h = (this.map.getHeight(e.x, e.y) + 1) * this.cellSize
+        const offset = (e.mesh.userData.baseOffset as number) || 0
         e.mesh.position.set(
           e.x * this.cellSize + this.cellSize / 2,
-          h,
+          h + offset * e.mesh.scale.y,
           e.y * this.cellSize + this.cellSize / 2
         )
         e.mesh.rotation.y = e.rot
@@ -466,9 +468,10 @@ export default class DungeonView3D {
         return
       }
       const h = (baseH + 1) * this.cellSize
+      const offset = (doll.userData.baseOffset as number) || 0
       doll.position.set(
         x * this.cellSize + this.cellSize / 2,
-        h,
+        h + offset,
         y * this.cellSize + this.cellSize / 2
       )
       this.blockyNPC = doll
@@ -518,7 +521,12 @@ export default class DungeonView3D {
     const baseH = this.map.getHeight(x, y)
     if (!this.map.isClearAbove(x, y, baseH + 1, vh)) return
     const h = (baseH + 1) * this.cellSize
-    mesh.position.set(x * this.cellSize + this.cellSize / 2, h, y * this.cellSize + this.cellSize / 2)
+    const offset = (mesh.userData.baseOffset as number) || 0
+    mesh.position.set(
+      x * this.cellSize + this.cellSize / 2,
+      h + offset * scale,
+      y * this.cellSize + this.cellSize / 2
+    )
     this.scene.add(mesh)
     this.environmentInstances.push({ template, x, y })
   }

--- a/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
+++ b/src/games/dungeon-rpg-three/components/BlockyCharacterLoader.ts
@@ -20,6 +20,7 @@ export interface PartSpec {
 
 export interface CharacterSpec {
   voxelHeight?: number
+  baseOffset?: number
   parts: PartSpec[]
 }
 
@@ -48,6 +49,9 @@ export default class BlockyCharacterLoader {
     }
     if (typeof spec.voxelHeight === 'number') {
       group.userData.voxelHeight = spec.voxelHeight
+    }
+    if (typeof spec.baseOffset === 'number') {
+      group.userData.baseOffset = spec.baseOffset
     }
     if (!Array.isArray(spec.parts)) {
       return group


### PR DESCRIPTION
## Summary
- document environment assets using `baseOffset`
- support optional `baseOffset` in environment JSON files
- mention environment support in character animation guide

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687fa31452f883338ebc763d26ff1581